### PR TITLE
Enable deletion of accounts

### DIFF
--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -289,9 +289,26 @@ namespace MyMoney.ViewModels.Pages
         }
 
         [RelayCommand]
-        private void DeleteAccount()
+        private async Task DeleteAccount()
         {
             if (SelectedAccountIndex < 0) return;
+
+            // Show message box asking user if they really want to delete the account
+            // show a message box
+            var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+            {
+                Title = "Delete Account?",
+                Content = "Are you sure you want to delete the selected Account?\nTHIS CANNOT BE UNDONE!",
+                IsPrimaryButtonEnabled = false,
+                IsSecondaryButtonEnabled = true,
+                SecondaryButtonText = "Yes",
+                CloseButtonText = "No",
+                CloseButtonAppearance = Wpf.Ui.Controls.ControlAppearance.Primary
+            };
+
+            var result = await uiMessageBox.ShowDialogAsync();
+
+            if (result != Wpf.Ui.Controls.MessageBoxResult.Secondary) return; // User clicked no
 
             Accounts.RemoveAt(SelectedAccountIndex);
 

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -42,6 +42,9 @@ namespace MyMoney.ViewModels.Pages
         private Account? _SelectedAccount;
 
         [ObservableProperty]
+        private int _SelectedAccountIndex = 0;
+
+        [ObservableProperty]
         private Transaction? _SelectedTransaction;
 
         [ObservableProperty]
@@ -283,6 +286,17 @@ namespace MyMoney.ViewModels.Pages
                     CategoryNames.Add(expenseCollection.FindById(i).Category);
                 }
             }
+        }
+
+        [RelayCommand]
+        private void DeleteAccount()
+        {
+            if (SelectedAccountIndex < 0) return;
+
+            Accounts.RemoveAt(SelectedAccountIndex);
+
+            // save changes to database
+            SaveAccountsToDatabase();
         }
     }
 }

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -26,12 +26,18 @@
 
         <StackPanel>
             <ui:Card Grid.Column="0" VerticalAlignment="Top" Margin="0,0,8,8">
-                <ui:ListView ItemsSource="{Binding ViewModel.Accounts}" SelectedItem="{Binding ViewModel.SelectedAccount, Mode=TwoWay}">
+                <ui:ListView ItemsSource="{Binding ViewModel.Accounts}" SelectedItem="{Binding ViewModel.SelectedAccount, Mode=TwoWay}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}">
                     <ui:ListView.ItemTemplate>
                         <DataTemplate DataType="{x:Type models:Account}">
                             <TextBlock Text="{Binding AccountName}" Margin="0,5,0,5"/>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>
+
+                    <ui:ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteAccountCommand}"/>
+                        </ContextMenu>
+                    </ui:ListView.ContextMenu>
                 </ui:ListView>
             </ui:Card>
 


### PR DESCRIPTION
Accounts can now be deleted by right-clicking on the account name and selecting "Delete" from the context menu. A message box warning that this cannot be undone is shown before the account is deleted. Closes #17 