### PR TITLE
Widen the date picker control

### DIFF
--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -127,7 +127,7 @@
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="125"/>
+                    <ColumnDefinition Width="135"/>
                     <ColumnDefinition Width="2*"/>
                     <ColumnDefinition Width="2*"/>
                     <ColumnDefinition Width="100"/>


### PR DESCRIPTION
The date picker control was too narrow to display the date. It's now 10 pixels wider so the whole date fits onto the control. Fixes #33 