### PR TITLE
Fixes crash when budget categories or accounts are deleted

### DIFF
--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -73,28 +73,37 @@ namespace MyMoney.ViewModels.Pages
 
                     Accounts.Add(account);
                 }
-
-                // load the category names from the database
-                var incomeCollection = db.GetCollection<BudgetIncomeItem>("BudgetIncomeItems");
-                var expenseCollection = db.GetCollection<BudgetExpenseItem>("BudgetExpenseItems");
-
-                // load the income items collection
-                for (int i = 1; i <= incomeCollection.Count(); i++)
-                {
-                    CategoryNames.Add(incomeCollection.FindById(i).Category);
-                }
-
-                // Load the expense items collection
-                for (int i = 1; i <= expenseCollection.Count(); i++)
-                {
-                    CategoryNames.Add(expenseCollection.FindById(i).Category);
-                }
             }
 
             AddNewAccountButtonClickCommand = new RelayCommand(BttnNewAccount_Click);
             AddTransactionButtonClickCommand = new RelayCommand(BttnNewTransaction_Click);
+
+            LoadCategoryNames();
         }
 
+        private void LoadCategoryNames()
+        {
+            CategoryNames.Clear();
+
+            using var db = new LiteDatabase(Helpers.DataFileLocationGetter.GetDataFilePath());
+
+            // load the category names from the database
+            var incomeCollection = db.GetCollection<BudgetIncomeItem>("BudgetIncomeItems");
+            var expenseCollection = db.GetCollection<BudgetExpenseItem>("BudgetExpenseItems");
+
+            // load the income items collection
+            for (int i = 1; i <= incomeCollection.Count(); i++)
+            {
+                CategoryNames.Add(incomeCollection.FindById(i).Category);
+            }
+
+            // Load the expense items collection
+            for (int i = 1; i <= expenseCollection.Count(); i++)
+            {
+                CategoryNames.Add(expenseCollection.FindById(i).Category);
+            }
+
+        }
 
         private void BttnNewAccount_Click()
         {
@@ -144,7 +153,7 @@ namespace MyMoney.ViewModels.Pages
 
                 decimal previousBalance = SelectedAccountTransactions[editTransactionIndex - 1].Balance.Value;
                 decimal newBalance = previousBalance - NewTransactionSpend.Value + NewTransactionReceive.Value;
-                
+
                 // Create the transaction object
                 Transaction newTransaction = new(NewTransactionDate, NewTransactionPayee, NewTransactionCategory, new(NewTransactionSpend.Value), new(NewTransactionReceive.Value), new(newBalance), NewTransactionMemo);
 
@@ -266,26 +275,7 @@ namespace MyMoney.ViewModels.Pages
         public void OnPageNavigatedTo()
         {
             // Reload the categories from the database
-            CategoryNames.Clear();
-
-            using (var db = new LiteDatabase(Helpers.DataFileLocationGetter.GetDataFilePath()))
-            {
-                // load the category names from the database
-                var incomeCollection = db.GetCollection<BudgetIncomeItem>("BudgetIncomeItems");
-                var expenseCollection = db.GetCollection<BudgetExpenseItem>("BudgetExpenseItems");
-
-                // load the income items collection
-                for (int i = 1; i <= incomeCollection.Count(); i++)
-                {
-                    CategoryNames.Add(incomeCollection.FindById(i).Category);
-                }
-
-                // Load the expense items collection
-                for (int i = 1; i <= expenseCollection.Count(); i++)
-                {
-                    CategoryNames.Add(expenseCollection.FindById(i).Category);
-                }
-            }
+            LoadCategoryNames();
         }
 
         [RelayCommand]

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -302,6 +302,12 @@ namespace MyMoney.ViewModels.Pages
 
             Accounts.RemoveAt(SelectedAccountIndex);
 
+            // Reset the IDs on the remaining accounts so they're in consecutive order
+            for (int i = 0; i < Accounts.Count; i++)
+            {
+                Accounts[i].Id = i + 1; // ID starts with 1, and loop counter with 0
+            }
+
             // save changes to database
             SaveAccountsToDatabase();
         }

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -162,9 +162,31 @@ namespace MyMoney.ViewModels.Pages
         }
 
         [RelayCommand]
-        private void DeleteIncomeItem()
+        private async Task DeleteIncomeItem()
         {
+            // Show message box asking user if they really want to delete the category
+            var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+            {
+                Title = "Delete Category?",
+                Content = "Are you sure you want to delete the selected Category?",
+                IsPrimaryButtonEnabled = false,
+                IsSecondaryButtonEnabled = true,
+                SecondaryButtonText = "Yes",
+                CloseButtonText = "No",
+                CloseButtonAppearance = Wpf.Ui.Controls.ControlAppearance.Primary
+            };
+
+            var result = await uiMessageBox.ShowDialogAsync();
+
+            if (result != Wpf.Ui.Controls.MessageBoxResult.Secondary) return; // User clicked no
             IncomeLineItems.RemoveAt(IncomeItemsSelectedIndex);
+
+            // replace the id property of the remaining elements so the IDs are in a concecutive order (We have all kinds of problems when we don't do this)
+            for (int i = 0; i < IncomeLineItems.Count; i++)
+            {
+                IncomeLineItems[i].Id = i + 1;
+            }
+
             UpdateListViewTotals();
         }
 
@@ -210,6 +232,13 @@ namespace MyMoney.ViewModels.Pages
 
             if (result != Wpf.Ui.Controls.MessageBoxResult.Secondary) return; // User clicked no
             ExpenseLineItems.RemoveAt(ExpenseItemsSelectedIndex);
+
+            // replace the id property of the remaining elements so the IDs are in a concecutive order (We have all kinds of problems when we don't do this)
+            for (int i = 0; i < ExpenseLineItems.Count; i++)
+            {
+                ExpenseLineItems[i].Id = i + 1;
+            }
+
             UpdateListViewTotals();
         }
     }


### PR DESCRIPTION
The program would crash when accounts or budget categories were deleted. This was because when an item was deleted, that left a gap in the IDs of the other items, so that not all the IDs were consecutive. A for loop retrieving items from the database would crash when it came to the gap in the IDs and got null instead of a real item. Fixes #37 