### PR TITLE
Stop including transfers in the income vs. expense chart

### DIFF
--- a/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
+++ b/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
@@ -64,6 +64,10 @@ namespace MyMoney.Core.Reports
 
             foreach (Transaction transaction in transactions)
             {
+                // Only list items with a category (this prevents beginning balances and transfers from showing up in the chart)
+                if (string.IsNullOrWhiteSpace(transaction.Category))
+                    continue;
+
                 income += transaction.Receive.Value;
             }
 
@@ -76,6 +80,9 @@ namespace MyMoney.Core.Reports
 
             foreach (Transaction transaction in transactions)
             {
+                // Only list items with a category (this prevents beginning balances and transfers from showing up in the chart)
+                if (string.IsNullOrWhiteSpace(transaction.Category))
+                    continue;
                 expenses += transaction.Spend.Value;
             }
 

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -110,8 +110,23 @@ namespace MyMoney.ViewModels.Pages
             }
         }
 
-        private void BttnNewTransaction_Click()
+        private async void BttnNewTransaction_Click()
         {
+            // Make sure that the required fields are filled out
+            if (NewTransactionCategory == "")
+            {
+                // Show message box
+                var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+                {
+                    Title = "Missing Category",
+                    Content = "Category field cannot be empty",
+                    CloseButtonText = "OK"
+                };
+
+                await uiMessageBox.ShowDialogAsync();
+                return;
+            }
+
             if (AddTransactionButtonText == "Add Transaction")
             {
                 // Calculate the balance


### PR DESCRIPTION
This prevents transfers from showing up in the 12 month income vs. expense chart. It also requires all transactions the user creates to have a category. Fixes #80 