### PR TITLE
Change total to remaining on budget report

### DIFF
--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -39,14 +39,6 @@ namespace MyMoney.ViewModels.Pages
         [ObservableProperty]
         private int _DifferenceColumnWidth = 100;
 
-
-        // Values for the budget report totals
-        [ObservableProperty]
-        private Currency _BudgetedTotal = new();
-
-        [ObservableProperty]
-        private Currency _ActualTotal = new();
-
         [ObservableProperty]
         private Currency _DifferenceTotal = new();
 
@@ -142,8 +134,8 @@ namespace MyMoney.ViewModels.Pages
             Expenses = (double)expenseTotal.Actual.Value;
 
             // Calulate budget report overall total
-            BudgetedTotal = incomeTotal.Budgeted - expenseTotal.Budgeted;
-            ActualTotal = incomeTotal.Actual - expenseTotal.Actual;
+            Currency BudgetedTotal = incomeTotal.Budgeted - expenseTotal.Budgeted;
+            Currency ActualTotal = incomeTotal.Actual - expenseTotal.Actual;
             DifferenceTotal = ActualTotal - BudgetedTotal;
 
 

--- a/MyMoney/Views/Pages/DashboardPage.xaml
+++ b/MyMoney/Views/Pages/DashboardPage.xaml
@@ -79,9 +79,7 @@
                                     <ColumnDefinition Width="{Binding ViewModel.DifferenceColumnWidth}"/>
                                 </Grid.ColumnDefinitions>
 
-                                <ui:TextBlock Grid.Column="0" FontTypography="BodyStrong" FontWeight="Bold">Totals</ui:TextBlock>
-                                <ui:TextBlock Grid.Column="1" FontTypography="BodyStrong" Text="{Binding ViewModel.BudgetedTotal}"/>
-                                <ui:TextBlock Grid.Column="2" FontTypography="BodyStrong" Text="{Binding ViewModel.ActualTotal}"/>
+                                <ui:TextBlock Grid.Column="0" FontTypography="BodyStrong" FontWeight="Bold">Remaining</ui:TextBlock>
                                 <ui:TextBlock Grid.Column="3" FontTypography="BodyStrong" Text="{Binding ViewModel.DifferenceTotal}"/>
                             </Grid>
                         </Border>


### PR DESCRIPTION
Remove the total for the budgeted and actual columns from budget report and change the word 'Totals' to 'Remaining'.