### PR TITLE
Redesign the accounts page

### DIFF
--- a/MyMoney.Core.FS/Models/Account.fs
+++ b/MyMoney.Core.FS/Models/Account.fs
@@ -1,8 +1,10 @@
 ﻿namespace MyMoney.Core.FS.Models
 
 open System.Collections.ObjectModel
+open System.ComponentModel
 
 type Account() =
+    let ev = new Event<PropertyChangedEventHandler, PropertyChangedEventArgs>()
     let mutable _Id = 0
     let mutable _Transactions = ObservableCollection<Transaction>()
     let mutable _AccountName = ""
@@ -18,8 +20,16 @@ type Account() =
 
     member this.AccountName
         with get () = _AccountName
-        and set (value) = _AccountName <- value
+        and set (value) = 
+            _AccountName <- value
+            ev.Trigger(this, PropertyChangedEventArgs("AccountName"))
 
     member this.Total
         with get () = _Total
-        and set (value) = _Total <- value
+        and set (value) = 
+            _Total <- value
+            ev.Trigger(this, PropertyChangedEventArgs("Total"))
+
+    interface INotifyPropertyChanged with
+        [<CLIEvent>]
+        member this.PropertyChanged = ev.Publish

--- a/MyMoney.Core.FS/Models/Transaction.fs
+++ b/MyMoney.Core.FS/Models/Transaction.fs
@@ -41,3 +41,16 @@ type Transaction (date:DateTime, payee:string, category:string, spend:Currency, 
 
     member this.DateFormatted
         with get() = _Date.ToShortDateString()
+
+    member this.MonthAbbreviated
+        with get() = _Date.ToString("MMM")
+
+    member this.AmountFormatted
+        with get() = 
+            if (_Spend.Value > 0m)
+                then "-" + _Spend.ToString()
+            elif(_Receive.Value > 0m)
+                then "+" + _Receive.ToString()
+            else
+                "$0.00"
+

--- a/MyMoney.Core.FS/Models/Transaction.fs
+++ b/MyMoney.Core.FS/Models/Transaction.fs
@@ -2,14 +2,12 @@
 
 open System
 
-type Transaction (date:DateTime, payee:string, category:string, spend:Currency, receive:Currency, balance:Currency, memo:string) =
+type Transaction (date:DateTime, payee:string, category:string, amount:Currency, memo:string) =
     let mutable _Payee = payee
     let mutable _Category = category
-    let mutable _Spend = spend
-    let mutable _Receive = receive
-    let mutable _Balance = balance
     let mutable _Memo = memo
     let mutable _Date = date
+    let mutable _Amount = amount
 
     member this.Payee 
         with get() = _Payee
@@ -19,17 +17,9 @@ type Transaction (date:DateTime, payee:string, category:string, spend:Currency, 
         with get() = _Category
         and set (value) = _Category <- value
 
-    member this.Spend 
-        with get() = _Spend
-        and set (value) = _Spend <- value
-
-    member this.Receive
-        with get() = _Receive
-        and set (value) = _Receive <- value
-
-    member this.Balance
-        with get() = _Balance
-        and set (value) = _Balance <- value
+    member this.Amount
+        with get() = _Amount
+        and set (value) = _Amount <- value
 
     member this.Memo
         with get() = _Memo
@@ -47,10 +37,12 @@ type Transaction (date:DateTime, payee:string, category:string, spend:Currency, 
 
     member this.AmountFormatted
         with get() = 
-            if (_Spend.Value > 0m)
-                then "-" + _Spend.ToString()
-            elif(_Receive.Value > 0m)
-                then "+" + _Receive.ToString()
+            if (_Amount.Value > 0m)
+                then "+" + _Amount.ToString()
+            elif(_Amount.Value < 0m) then
+                let t = Math.Abs(_Amount.Value)
+                let tc = new Currency(t)
+                "-" + tc.ToString()
             else
                 "$0.00"
 

--- a/MyMoney.Core/Reports/BudgetReportCalculator.cs
+++ b/MyMoney.Core/Reports/BudgetReportCalculator.cs
@@ -85,7 +85,8 @@ namespace MyMoney.Core.Reports
                 {
                     if (transaction.Category == CategoryName && IsDateInCurrentMonth(transaction.Date))
                     {
-                        Actual += transaction.Receive.Value;
+                        // TODO: Only use income transactions
+                        Actual += transaction.Amount.Value;
                     }
                 }
             }
@@ -109,7 +110,8 @@ namespace MyMoney.Core.Reports
                 {
                     if (transaction.Category == CategoryName && IsDateInCurrentMonth(transaction.Date))
                     {
-                        Actual += transaction.Spend.Value;
+                        // TODO: Only use expense transactions
+                        Actual += transaction.Amount.Value;
                     }
                 }
             }

--- a/MyMoney.Core/Reports/BudgetReportCalculator.cs
+++ b/MyMoney.Core/Reports/BudgetReportCalculator.cs
@@ -26,7 +26,7 @@ namespace MyMoney.Core.Reports
                 {
                     Category = item.Category,
                     Budgeted = item.Amount,
-                    Actual = CalculateTotalIncomeForCategory(item.Category),
+                    Actual = CalculateTotalForCategory(item.Category),
                 };
 
                 budgetReportItem.Remaining = new(
@@ -58,7 +58,7 @@ namespace MyMoney.Core.Reports
                 {
                     Category = item.Category,
                     Budgeted = item.Amount,
-                    Actual = CalculateTotalExpensesForCategory(item.Category),
+                    Actual = new(Math.Abs(CalculateTotalForCategory(item.Category).Value)),
                 };
 
                 budgetReportItem.Remaining = budgetReportItem.Budgeted - budgetReportItem.Actual;
@@ -69,7 +69,7 @@ namespace MyMoney.Core.Reports
             return budgetReportItems;
         }
 
-        private static Currency CalculateTotalIncomeForCategory(string CategoryName)
+        private static Currency CalculateTotalForCategory(string CategoryName)
         {
             // Read the accounts from the database
             var accounts = Database.DatabaseReader.GetCollection<Account>("Accounts");
@@ -85,32 +85,6 @@ namespace MyMoney.Core.Reports
                 {
                     if (transaction.Category == CategoryName && IsDateInCurrentMonth(transaction.Date))
                     {
-                        // TODO: Only use income transactions
-                        Actual += transaction.Amount.Value;
-                    }
-                }
-            }
-
-            return new Currency(Actual);
-        }
-
-        private static Currency CalculateTotalExpensesForCategory(string CategoryName)
-        {
-            // Read the accounts from the database
-            var accounts = Database.DatabaseReader.GetCollection<Account>("Accounts");
-
-            // search through each account for transactions in this category that happened this month
-
-            // Total for this category so far
-            decimal Actual = 0m;
-
-            foreach (var account in accounts)
-            {
-                foreach (var transaction in account.Transactions)
-                {
-                    if (transaction.Category == CategoryName && IsDateInCurrentMonth(transaction.Date))
-                    {
-                        // TODO: Only use expense transactions
                         Actual += transaction.Amount.Value;
                     }
                 }

--- a/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
+++ b/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
@@ -68,7 +68,8 @@ namespace MyMoney.Core.Reports
                 if (string.IsNullOrWhiteSpace(transaction.Category))
                     continue;
 
-                income += transaction.Receive.Value;
+                // TODO: Only use the income amounts
+                income += transaction.Amount.Value;
             }
 
             return income;
@@ -83,7 +84,8 @@ namespace MyMoney.Core.Reports
                 // Only list items with a category (this prevents beginning balances and transfers from showing up in the chart)
                 if (string.IsNullOrWhiteSpace(transaction.Category))
                     continue;
-                expenses += transaction.Spend.Value;
+                // TODO: Only use the expense amounts
+                expenses += transaction.Amount.Value;
             }
 
             return expenses;

--- a/MyMoney.Tests/AssemblyInitialize.cs
+++ b/MyMoney.Tests/AssemblyInitialize.cs
@@ -45,13 +45,12 @@ namespace MyMoney.Tests
             // Create an account
             Account account = new();
             account.AccountName = "Account";
-            account.Transactions.Add(new Transaction(DateTime.Today, "Begining Balance", string.Empty, new(0.00m), new(0.0m), new(5000), string.Empty));
             account.Total = new(2000);
 
             // Add some transactions
-            account.Transactions.Add(new Transaction(DateTime.Today, "My Job, Inc.", "Income", new(0m), new(500), new(2500), "Paycheck"));
-            account.Transactions.Add(new Transaction(DateTime.Today, "Gas Station", "Auto", new(50m), new(0m), new(2450m), "Fill up car"));
-            account.Transactions.Add(new Transaction(DateTime.Today, "Fast Food, Inc.", "Food", new(20m), new(0m), new(2430), "Lunch"));
+            account.Transactions.Add(new Transaction(DateTime.Today, "My Job, Inc.", "Income",new(500), "Paycheck"));
+            account.Transactions.Add(new Transaction(DateTime.Today, "Gas Station", "Auto", new(-50m), "Fill up car"));
+            account.Transactions.Add(new Transaction(DateTime.Today, "Fast Food, Inc.", "Food", new(-20m), "Lunch"));
             account.Total = new(2430);
 
             // Write account to the database

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModelTest.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModelTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Wpf.Ui;
 
 namespace MyMoney.Tests.ViewModelTests
 {
@@ -13,14 +14,14 @@ namespace MyMoney.Tests.ViewModelTests
         [TestMethod]
         public void Test_AccountsAreLoaded()
         {
-            AccountsViewModel viewModel = new();
+            AccountsViewModel viewModel = new(new ContentDialogService());
             Assert.AreEqual(1, viewModel.Accounts.Count);
         }
 
         [TestMethod]
         public void Test_CategoryNamesAreLoaded()
         {
-            AccountsViewModel viewModel = new();
+            AccountsViewModel viewModel = new(new ContentDialogService());
             Assert.AreEqual(7, viewModel.CategoryNames.Count);
         }
     }

--- a/MyMoney/Helpers/CurrencyConverter.cs
+++ b/MyMoney/Helpers/CurrencyConverter.cs
@@ -1,0 +1,27 @@
+﻿using MyMoney.Core.FS.Models;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace MyMoney.Helpers
+{
+    public class CurrencyConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Currency currency) 
+            { 
+                return currency.ToString();
+            }
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is string text && decimal.TryParse(text, out decimal result))
+            {
+                return new Currency(result);
+            }
+            return DependencyProperty.UnsetValue;
+        }
+    }
+}

--- a/MyMoney/Helpers/StartsWithPlusConverter.cs
+++ b/MyMoney/Helpers/StartsWithPlusConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace MyMoney.Helpers
+{
+    public class StartsWithPlusConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) 
+        { 
+            if (value is string stringValue) 
+            { 
+                return stringValue.StartsWith('+');
+            } 
+            
+            return false; 
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) 
+        { 
+            throw new NotImplementedException(); 
+        }
+    }
+}

--- a/MyMoney/ViewModels/ContentDialogs/RenameAccountViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/RenameAccountViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace MyMoney.ViewModels.ContentDialogs
+{
+    public partial class RenameAccountViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string _NewName = string.Empty;
+    }
+}

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -305,10 +305,11 @@ namespace MyMoney.ViewModels.Pages
         [RelayCommand]
         private async Task DeleteTransaction()
         {
-            // Do not delete the first transaction (opening balance)
-            if (SelectedTransactionIndex <= 0) return;
+            // Make sure a transaction is selected
+            if (SelectedAccount == null) return;
+            if (SelectedTransactionIndex < 0) return;
 
-            // show a message box
+            // confirm deletion
             var uiMessageBox = new Wpf.Ui.Controls.MessageBox
             {
                 Title = "Delete Transaction?",
@@ -321,6 +322,10 @@ namespace MyMoney.ViewModels.Pages
             var result = await uiMessageBox.ShowDialogAsync();
 
             if (result != Wpf.Ui.Controls.MessageBoxResult.Primary) return; // User clicked no
+
+            // get the amount of the selected transaction so we can modify the account total
+            var amount = SelectedAccountTransactions[SelectedTransactionIndex].Amount;
+            SelectedAccount.Total -= amount;
 
             // Delete the selected transaction
             SelectedAccountTransactions.RemoveAt(SelectedTransactionIndex);

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -135,6 +135,20 @@ namespace MyMoney.ViewModels.Pages
 
         private async void BttnNewTransaction_Click()
         {
+            // make sure an account is selected
+            if (SelectedAccountIndex == -1)
+            {
+                var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+                {
+                    Title = "Select Account",
+                    Content = "Select an account before adding a transaction",
+                    CloseButtonText = "OK",
+                };
+
+                await uiMessageBox.ShowDialogAsync();
+                return;
+            }
+
             var dialogHost = _contentDialogService.GetDialogHost();
             if (dialogHost == null) return;
 

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -159,7 +159,11 @@ namespace MyMoney.ViewModels.Pages
             };
             var result = await renameContentDialog.ShowAsync();
 
-            if (result != ContentDialogResult.Primary) return;
+            if (result != ContentDialogResult.Primary)
+            {
+                ClearNewTransactionFields();
+                return;
+            }
 
             // Make sure that the required fields are filled out
             if (NewTransactionCategory == "")
@@ -173,6 +177,7 @@ namespace MyMoney.ViewModels.Pages
                 };
 
                 await uiMessageBox.ShowDialogAsync();
+                ClearNewTransactionFields();
                 return;
             }
             if (NewTransactionAmount.Value <= 0m)
@@ -186,6 +191,7 @@ namespace MyMoney.ViewModels.Pages
                 };
 
                 await uiMessageBox.ShowDialogAsync();
+                ClearNewTransactionFields();
                 return;
             }
 
@@ -201,15 +207,20 @@ namespace MyMoney.ViewModels.Pages
             Transaction newTransaction = new(NewTransactionDate, NewTransactionPayee, NewTransactionCategory, amount, NewTransactionMemo);
             SelectedAccountTransactions.Add(newTransaction);
 
+            ClearNewTransactionFields();
+
+            SortTransactions();
+
+            SaveAccountsToDatabase();
+        }
+
+        private void ClearNewTransactionFields()
+        {
             NewTransactionDate = DateTime.Today;
             NewTransactionPayee = "";
             NewTransactionCategory = "";
             NewTransactionAmount = new(0m);
             NewTransactionMemo = "";
-
-            SortTransactions();
-
-            SaveAccountsToDatabase();
         }
 
         [RelayCommand]

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -91,6 +91,19 @@ namespace MyMoney.ViewModels.Pages
 
         }
 
+        private void SortTransactions()
+        {
+            var sorted = SelectedAccountTransactions.OrderByDescending(p => p.Date).ToList();
+            if (sorted != null)
+            {
+                SelectedAccountTransactions.Clear();
+                foreach (var transaction in sorted)
+                {
+                    SelectedAccountTransactions.Add(transaction);
+                }
+            }
+        }
+
         private void BttnNewAccount_Click()
         {
             // Show the new account dialog
@@ -189,6 +202,8 @@ namespace MyMoney.ViewModels.Pages
             NewTransactionReceive = new(0m);
             NewTransactionMemo = "";
 
+            SortTransactions();
+
             SaveAccountsToDatabase();
         }
 
@@ -240,6 +255,8 @@ namespace MyMoney.ViewModels.Pages
                     }
                 }
 
+                SortTransactions();
+
                 // save the accounts to the database
                 SaveAccountsToDatabase();
             }
@@ -251,6 +268,8 @@ namespace MyMoney.ViewModels.Pages
 
             if (SelectedAccount != null) IsInputEnabled = true;
             else IsInputEnabled = false;
+
+            SortTransactions();
         }
 
         partial void OnSelectedTransactionChanged(Transaction? value)

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -3,6 +3,11 @@ using MyMoney.Views.Windows;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using MyMoney.Core.FS.Models;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+using Wpf.Ui.Extensions;
+using MyMoney.Views.ContentDialogs;
+using MyMoney.ViewModels.ContentDialogs;
 
 
 namespace MyMoney.ViewModels.Pages
@@ -47,8 +52,12 @@ namespace MyMoney.ViewModels.Pages
         [ObservableProperty]
         private string _AddTransactionButtonText = "Add Transaction";
 
-        public AccountsViewModel()
+        private readonly IContentDialogService _contentDialogService;
+
+        public AccountsViewModel(IContentDialogService contentDialogService)
         {
+            _contentDialogService = contentDialogService;
+
             var a = Core.Database.DatabaseReader.GetCollection<Account>("Accounts");
 
             foreach (var account in a)
@@ -288,6 +297,32 @@ namespace MyMoney.ViewModels.Pages
             }
 
             // save changes to database
+            SaveAccountsToDatabase();
+        }
+
+        [RelayCommand]
+        private async Task RenameAccount(object content)
+        {
+            var dialogHost = _contentDialogService.GetDialogHost();
+            if (dialogHost == null) return;
+
+            RenameAccountViewModel renameViewModel = new()
+            {
+                NewName = Accounts[SelectedAccountIndex].AccountName
+            };
+
+            var renameContentDialog = new RenameAccountDialog(dialogHost, renameViewModel)
+            {
+                PrimaryButtonText = "Rename",
+                CloseButtonText = "Cancel",
+            };
+            var result = await renameContentDialog.ShowAsync();
+
+            if (result == ContentDialogResult.Primary)
+            {
+                Accounts[SelectedAccountIndex].AccountName = renameViewModel.NewName;
+            }
+
             SaveAccountsToDatabase();
         }
     }

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -38,6 +38,12 @@ namespace MyMoney.ViewModels.Pages
         private Currency _NewTransactionAmount = new(0m);
 
         [ObservableProperty]
+        private bool _NewTransactionIsExpense = true;
+
+        [ObservableProperty]
+        private bool _NewTransactionIsIncome = false;
+
+        [ObservableProperty]
         private Account? _SelectedAccount;
 
         [ObservableProperty]
@@ -144,13 +150,16 @@ namespace MyMoney.ViewModels.Pages
                 return;
             }
 
+            var amount = NewTransactionAmount;
+            if (NewTransactionIsExpense) amount = new(-amount.Value);
+
             // Calculate the balance
             if (SelectedAccount == null) return;
-            var balance = SelectedAccount.Total + NewTransactionAmount;
+            var balance = SelectedAccount.Total + amount;
 
             SelectedAccount.Total = balance;
 
-            Transaction newTransaction = new(NewTransactionDate, NewTransactionPayee, NewTransactionCategory, new(NewTransactionAmount.Value), NewTransactionMemo);
+            Transaction newTransaction = new(NewTransactionDate, NewTransactionPayee, NewTransactionCategory, amount, NewTransactionMemo);
             SelectedAccountTransactions.Add(newTransaction);
 
             NewTransactionDate = DateTime.Today;
@@ -162,6 +171,16 @@ namespace MyMoney.ViewModels.Pages
             SortTransactions();
 
             SaveAccountsToDatabase();
+        }
+
+        [RelayCommand]
+        private void ClearTransaction()
+        {
+            NewTransactionAmount = new(0m);
+            NewTransactionCategory = "";
+            NewTransactionDate = DateTime.Today;
+            NewTransactionMemo = "";
+            NewTransactionPayee = "";
         }
 
         [RelayCommand]

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -135,6 +135,18 @@ namespace MyMoney.ViewModels.Pages
 
         private async void BttnNewTransaction_Click()
         {
+            var dialogHost = _contentDialogService.GetDialogHost();
+            if (dialogHost == null) return;
+
+            var renameContentDialog = new NewTransactionDialog(dialogHost, this)
+            {
+                PrimaryButtonText = "OK",
+                CloseButtonText = "Cancel",
+            };
+            var result = await renameContentDialog.ShowAsync();
+
+            if (result != ContentDialogResult.Primary) return;
+
             // Make sure that the required fields are filled out
             if (NewTransactionCategory == "")
             {

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -50,9 +50,6 @@ namespace MyMoney.ViewModels.Pages
         [ObservableProperty]
         private string _AddTransactionButtonText = "Add Transaction";
 
-        [ObservableProperty]
-        private double _TransactionsMaxHeight;
-
         public AccountsViewModel()
         {
             var a = Core.Database.DatabaseReader.GetCollection<Account>("Accounts");

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -149,6 +149,19 @@ namespace MyMoney.ViewModels.Pages
                 await uiMessageBox.ShowDialogAsync();
                 return;
             }
+            if (NewTransactionAmount.Value <= 0m)
+            {
+                // Show message box
+                var uiMessageBox = new Wpf.Ui.Controls.MessageBox
+                {
+                    Title = "Invalid Amount",
+                    Content = "Amount must be a number more than $0.00",
+                    CloseButtonText = "OK"
+                };
+
+                await uiMessageBox.ShowDialogAsync();
+                return;
+            }
 
             var amount = NewTransactionAmount;
             if (NewTransactionIsExpense) amount = new(-amount.Value);

--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -169,7 +169,7 @@ namespace MyMoney.ViewModels.Pages
             var AccentColor = ApplicationAccentColorManager.GetColorizationColor();
             ISeries[] s = [new ColumnSeries<double>()
             {
-                Values = new [] {Income, Expenses},
+                Values = [Income, Expenses],
                 Fill = new SolidColorPaint(new SKColor(AccentColor.R, AccentColor.G, AccentColor.B)),
                 Stroke = null,
             }];

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -52,6 +52,6 @@
         <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
         <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}" Margin="0,0,0,4"/>
         <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
-        <ui:TextBox Margin="0,0,0,24" Text="{Binding NewTransactionMemo}"/>
+        <ui:TextBox x:Name="txtMemo" Margin="0,0,0,24" Text="{Binding NewTransactionMemo}" KeyDown="TextBox_KeyDown"/>
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -1,0 +1,56 @@
+﻿<ui:ContentDialog x:Class="MyMoney.Views.ContentDialogs.NewTransactionDialog"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
+      xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" 
+      xmlns:helpers="clr-namespace:MyMoney.Helpers" xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs" xmlns:pages="clr-namespace:MyMoney.ViewModels.Pages"
+                  Title="New Transaction"
+                  d:DataContext="{d:DesignInstance {x:Type pages:AccountsViewModel}, IsDesignTimeCreatable=False}"
+      ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+      ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+      Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+    <ui:ContentDialog.Resources>
+        <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
+        <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewTransactionDialog}" />
+    </ui:ContentDialog.Resources>
+
+    <StackPanel>
+        <ui:TextBlock Margin="0,0,0,4">Transaction type</ui:TextBlock>
+        <Grid Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+            <RadioButton Grid.Column="1" IsChecked="{Binding NewTransactionIsIncome}">Income</RadioButton>
+            <RadioButton Grid.Column="0" IsChecked="{Binding NewTransactionIsExpense}">Expense</RadioButton>
+        </Grid>
+        <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
+        <ui:TextBox Margin="0,0,0,16" Text="{Binding Path=NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"/>
+        <Grid Margin="0,0,0,16">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="135"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <ui:TextBlock Margin="0,0,0,4">Date</ui:TextBlock>
+            <DatePicker Grid.Row="1" Margin="0,0,4,0" SelectedDateFormat="Short" IsTodayHighlighted="True"
+                                    SelectedDate="{Binding NewTransactionDate}"/>
+            <ui:TextBlock Grid.Column="1" Grid.Row="0" Margin="4,0,0,4">Payee</ui:TextBlock>
+            <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0" Text="{Binding NewTransactionPayee}"/>
+        </Grid>
+        <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
+        <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}"/>
+        <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
+        <ui:TextBox Margin="0,0,0,24" Text="{Binding NewTransactionMemo}"/>
+    </StackPanel>
+</ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -50,7 +50,16 @@
             <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0" Text="{Binding NewTransactionPayee}"/>
         </Grid>
         <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
-        <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}" Margin="0,0,0,4"/>
+        <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}" Margin="0,0,0,16"/>
+        <ui:TextBlock Margin="0,0,0,4">Account</ui:TextBlock>
+        <ComboBox Margin="0,0,0,16" ItemsSource="{Binding Accounts}" SelectedIndex="{Binding SelectedAccountIndex}"
+                  SelectedItem="{Binding SelectedAccount}">
+            <ComboBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding AccountName}"/>
+                </DataTemplate>
+            </ComboBox.ItemTemplate>
+        </ComboBox>
         <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
         <ui:TextBox x:Name="txtMemo" Margin="0,0,0,24" Text="{Binding NewTransactionMemo}" KeyDown="TextBox_KeyDown"/>
     </StackPanel>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -14,7 +14,8 @@
                   d:DataContext="{d:DesignInstance {x:Type pages:AccountsViewModel}, IsDesignTimeCreatable=False}"
       ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
       ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-      Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+      Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+      Loaded="ContentDialog_Loaded">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewTransactionDialog}" />
@@ -31,7 +32,7 @@
             <RadioButton Grid.Column="0" IsChecked="{Binding NewTransactionIsExpense}">Expense</RadioButton>
         </Grid>
         <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
-        <ui:TextBox Margin="0,0,0,16" Text="{Binding Path=NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"/>
+        <ui:TextBox x:Name="txtAmount" Margin="0,0,0,16" Text="{Binding Path=NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"/>
         <Grid Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="135"/>
@@ -49,7 +50,7 @@
             <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0" Text="{Binding NewTransactionPayee}"/>
         </Grid>
         <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
-        <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}"/>
+        <ComboBox ItemsSource="{Binding CategoryNames}" Text="{Binding NewTransactionCategory}" Margin="0,0,0,4"/>
         <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
         <ui:TextBox Margin="0,0,0,24" Text="{Binding NewTransactionMemo}"/>
     </StackPanel>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -1,0 +1,32 @@
+﻿using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.ViewModels.Pages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Views.ContentDialogs
+{
+    /// <summary>
+    /// Interaction logic for NewTransactionDialog.xaml
+    /// </summary>
+    public partial class NewTransactionDialog : ContentDialog
+    {
+        public NewTransactionDialog(ContentPresenter dialogHost, AccountsViewModel viewModel) : base(dialogHost)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+        }
+    }
+}

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -28,5 +28,11 @@ namespace MyMoney.Views.ContentDialogs
             InitializeComponent();
             DataContext = viewModel;
         }
+
+        private void ContentDialog_Loaded(object sender, RoutedEventArgs e)
+        {
+            txtAmount.Focus();
+            txtAmount.SelectAll();
+        }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -34,5 +34,15 @@ namespace MyMoney.Views.ContentDialogs
             txtAmount.Focus();
             txtAmount.SelectAll();
         }
+
+        private void TextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            // tab to next control (OK button) and press enter on it (submit the dialog) when enter is pressed
+            if (e.Key == Key.Enter)
+            {
+                txtMemo.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+                e.Handled = false;
+            }
+        }
     }
 }

--- a/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml
@@ -1,0 +1,22 @@
+﻿<ui:ContentDialog x:Class="MyMoney.Views.ContentDialogs.RenameAccountDialog"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs" xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs" 
+      d:DataContext="{d:DesignInstance Type=contentdialogs:RenameAccountViewModel}"
+      ui:Design.Background="{ui:ThemeResource ApplicationBackgroundBrush}"
+      ui:Design.Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="600"
+      Title="Rename Account"
+      Loaded="ContentDialog_Loaded">
+    <ui:ContentDialog.Resources>
+        <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:RenameAccountDialog}" />
+    </ui:ContentDialog.Resources>
+    <StackPanel>
+        <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
+        <TextBox x:Name="txtNewName" HorizontalAlignment="Stretch" Text="{Binding NewName}" KeyDown="txtNewName_KeyDown"/>
+    </StackPanel>
+</ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml.cs
@@ -1,0 +1,35 @@
+﻿using MyMoney.ViewModels.ContentDialogs;
+using System;
+using System.Windows.Controls;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Views.ContentDialogs
+{
+    /// <summary>
+    /// Interaction logic for RenameAccountDialog.xaml
+    /// </summary>
+    public partial class RenameAccountDialog : ContentDialog
+    {
+        public RenameAccountDialog(ContentPresenter dialogHost, RenameAccountViewModel viewModel) : base(dialogHost)
+        {
+            InitializeComponent();
+
+            DataContext = viewModel;
+        }
+
+        private void ContentDialog_Loaded(object sender, RoutedEventArgs e)
+        {
+            txtNewName.SelectAll();
+            txtNewName.Focus();
+        }
+
+        private void txtNewName_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Enter)
+            {
+                txtNewName.MoveFocus(new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next));
+                e.Handled = false;
+            }
+        }
+    }
+}

--- a/MyMoney/Views/Controls/MonthDayControl.xaml
+++ b/MyMoney/Views/Controls/MonthDayControl.xaml
@@ -1,0 +1,21 @@
+﻿<UserControl x:Class="MyMoney.Views.Controls.MonthDayControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:local="clr-namespace:MyMoney.Views.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             d:DataContext="{d:DesignInstance local:MonthDayControl, IsDesignTimeCreatable=False}">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ui:TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Day,
+            RelativeSource={RelativeSource AncestorType=UserControl}}" FontSize="18" FontWeight="SemiBold"/>
+        <ui:TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Month,
+            RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+    </Grid>
+</UserControl>

--- a/MyMoney/Views/Controls/MonthDayControl.xaml.cs
+++ b/MyMoney/Views/Controls/MonthDayControl.xaml.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MyMoney.Views.Controls
+{
+    /// <summary>
+    /// Interaction logic for MonthDayControl.xaml
+    /// </summary>
+    public partial class MonthDayControl : UserControl
+    {
+        public MonthDayControl()
+        {
+            InitializeComponent();
+        }
+
+        public string Month
+        {
+            get
+            {
+                return (string)GetValue(MonthProperty);
+            }
+
+            set
+            {
+                SetValue(MonthProperty, value);
+            }
+        }
+        public static readonly DependencyProperty MonthProperty = DependencyProperty.Register("Month", typeof(string), typeof(MonthDayControl), new PropertyMetadata(string.Empty));
+        
+        
+        public int Day
+        {
+            get
+            {
+                return (int)GetValue(DayProperty);
+            }
+            set
+            {
+                SetValue(DayProperty, value);
+            }
+        }
+        public static readonly DependencyProperty DayProperty = DependencyProperty.Register("Day", typeof(int), typeof(MonthDayControl), new PropertyMetadata(0));
+    }
+}

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="MyMoney.Views.Pages.AccountsPage"
+﻿<Page
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -7,15 +7,15 @@
       xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
       xmlns:local="clr-namespace:MyMoney.Views.Pages" 
       xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
+      xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" xmlns:Controls="clr-namespace:MyMoney.Views.Controls" x:Class="MyMoney.Views.Pages.AccountsPage"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="Accounts"
-      d:DataContext="{d:DesignInstance local:AccountsPage,
-                                 IsDesignTimeCreatable=False}"
+      d:DataContext="{d:DesignInstance {x:Type local:AccountsPage}, IsDesignTimeCreatable=False}"
       ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
       ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-      xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" Loaded="Page_Loaded"
+      Loaded="Page_Loaded"
       >
 
     <Grid>
@@ -43,7 +43,7 @@
                               SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                               SelectedItem="{Binding ViewModel.SelectedTransaction}">
                     <ui:ListView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate DataType="{x:Type models:Transaction}">
                             <Grid Margin="0,2,0,2">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="1*"/>
@@ -55,13 +55,12 @@
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
 
-                                <ui:TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Date.Day}" FontSize="18" FontWeight="SemiBold"/>
-                                <ui:TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding MonthAbbreviated}"/>
+                                <Controls:MonthDayControl Grid.RowSpan="2" Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" HorizontalAlignment="Left" Margin="16,0,0,0"/>
 
                                 <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
                                 <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
 
-                                <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right"/>
+                                <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0"/>
                             </Grid>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -81,6 +81,7 @@
                                   SelectedItem="{Binding ViewModel.SelectedTransaction}" VerticalAlignment="Top">
                     <ui:ListView.ContextMenu>
                         <ContextMenu>
+                            <MenuItem Header="Edit" Command="{Binding ViewModel.EditTransactionCommand}"/>
                             <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteTransactionCommand}"/>
                         </ContextMenu>
                     </ui:ListView.ContextMenu>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -8,6 +8,7 @@
       xmlns:local="clr-namespace:MyMoney.Views.Pages" 
       xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
       xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" xmlns:Controls="clr-namespace:MyMoney.Views.Controls" x:Class="MyMoney.Views.Pages.AccountsPage"
+      xmlns:helpers="clr-namespace:MyMoney.Helpers"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="Accounts"
@@ -17,6 +18,9 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       Loaded="Page_Loaded"
       >
+    <Page.Resources>
+        <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
+    </Page.Resources>
 
     <Grid>
         <Grid.ColumnDefinitions>
@@ -30,7 +34,7 @@
             </Grid.RowDefinitions>
 
 
-            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,0,0,0" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,0,0,24" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -67,7 +71,18 @@
                                     <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
                                     <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
 
-                                    <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0"/>
+                                    <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" FontWeight="SemiBold"
+                                                  Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0">
+                                        <ui:TextBlock.Style>
+                                            <Style TargetType="ui:TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter} }" Value="True">
+                                                        <Setter Property="Foreground" Value="{DynamicResource AccentTextFillColorTertiaryBrush}"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ui:TextBlock.Style>
+                                    </ui:TextBlock>
                                 </Grid>
                             </DataTemplate>
                         </ui:ListView.ItemTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -10,7 +10,7 @@
       xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" xmlns:Controls="clr-namespace:MyMoney.Views.Controls" x:Class="MyMoney.Views.Pages.AccountsPage"
       xmlns:helpers="clr-namespace:MyMoney.Helpers"
       mc:Ignorable="d" 
-      d:DesignHeight="500" d:DesignWidth="800"
+      d:DesignHeight="800" d:DesignWidth="1200"
       Title="Accounts"
       d:DataContext="{d:DesignInstance {x:Type local:AccountsPage}, IsDesignTimeCreatable=False}"
       ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
@@ -93,6 +93,10 @@
         </Grid>
 
         <Grid Grid.Column="1" Margin="24,0,0,24">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="1*"/>
+            </Grid.RowDefinitions>
             <ui:Card VerticalAlignment="Top">
                 <StackPanel Margin="8,0,8,0">
                     <ui:TextBlock FontTypography="Subtitle" Margin="0,16,0,24">New Transaction</ui:TextBlock>
@@ -135,6 +139,49 @@
 
                     
                 </StackPanel>
+            </ui:Card>
+
+            <ui:Card Grid.Row="1" VerticalAlignment="Top" Margin="0,24,0,0">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*"/>
+                        <ColumnDefinition Width="1*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="1*"/>
+                    </Grid.RowDefinitions>
+                    <ui:TextBlock FontTypography="Subtitle" Margin="0,0,0,8">Accounts</ui:TextBlock>
+                    
+                    <StackPanel Grid.Column="0" Grid.Row="1">
+                        <ui:ListView MaxHeight="200" ItemsSource="{Binding ViewModel.Accounts}">
+                            <ui:ListView.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="1*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <ui:TextBlock Text="{Binding AccountName}" Margin="4"/>
+                                        <ui:TextBlock Grid.Column="1" Text="{Binding Total}" Margin="4"/>
+                                    </Grid>
+                                    
+                                </DataTemplate>
+                            </ui:ListView.ItemTemplate>
+
+                            <ui:ListView.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Delete Account"/>
+                                </ContextMenu>
+                            </ui:ListView.ContextMenu>
+                        </ui:ListView>
+                    </StackPanel>
+                    
+                    <StackPanel Grid.Column="1" Grid.Row="1" Margin="16,0,0,0">
+                        <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8">New Account</ui:Button>
+                        <ui:Button HorizontalAlignment="Stretch">Transfer</ui:Button>
+                    </StackPanel>
+                </Grid>
             </ui:Card>
         </Grid>
     </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -25,7 +25,7 @@
         </Grid.ColumnDefinitions>
 
         <StackPanel>
-            <ComboBox ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
+            <ComboBox x:Name="cmbAccounts" ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
                       SelectedItem="{Binding ViewModel.SelectedAccount}">
                 <ComboBox.ItemTemplate>
                     <DataTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -113,11 +113,11 @@
                             <ColumnDefinition Width="1*"/>
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
-                        <RadioButton Grid.Column="1">Income</RadioButton>
-                        <RadioButton Grid.Column="0">Expense</RadioButton>
+                        <RadioButton Grid.Column="1" IsChecked="{Binding ViewModel.NewTransactionIsIncome}">Income</RadioButton>
+                        <RadioButton Grid.Column="0" IsChecked="{Binding ViewModel.NewTransactionIsExpense}">Expense</RadioButton>
                     </Grid>
                     <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
-                    <ui:NumberBox MaxDecimalPlaces="2" Margin="0,0,0,16"/>
+                    <ui:TextBox Margin="0,0,0,16" Text="{Binding ViewModel.NewTransactionAmount.Value}"/>
                     <Grid Margin="0,0,0,16">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="135"/>
@@ -129,19 +129,24 @@
                         </Grid.RowDefinitions>
 
                         <ui:TextBlock Margin="0,0,0,4">Date</ui:TextBlock>
-                        <DatePicker Grid.Row="1" Margin="0,0,4,0" SelectedDateFormat="Short" IsTodayHighlighted="True"/>
+                        <DatePicker Grid.Row="1" Margin="0,0,4,0" SelectedDateFormat="Short" IsTodayHighlighted="True"
+                                    SelectedDate="{Binding ViewModel.NewTransactionDate}"/>
                         <ui:TextBlock Grid.Column="1" Grid.Row="0" Margin="4,0,0,4">Payee</ui:TextBlock>
-                        <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0"/>
+                        <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0" Text="{Binding ViewModel.NewTransactionPayee}"/>
                     </Grid>
+                    <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
+                    <ComboBox ItemsSource="{Binding ViewModel.CategoryNames}" Text="{Binding ViewModel.NewTransactionCategory}"/>
                     <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
-                    <ui:TextBox Margin="0,0,0,24"/>
+                    <ui:TextBox Margin="0,0,0,24" Text="{Binding ViewModel.NewTransactionMemo}"/>
                     <Grid Margin="0,0,0,8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="1*"/>
                             <ColumnDefinition Width="1*"/>
                         </Grid.ColumnDefinitions>
-                        <ui:Button Grid.Column="0" Appearance="Primary" HorizontalAlignment="Stretch" Margin="0,0,4,0">Add</ui:Button>
-                        <ui:Button Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,0,0,0">Clear</ui:Button>
+                        <ui:Button Grid.Column="0" Appearance="Primary" HorizontalAlignment="Stretch" Margin="0,0,4,0"
+                                   Command="{Binding ViewModel.AddTransactionButtonClickCommand}">Add</ui:Button>
+                        <ui:Button Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,0,0,0"
+                                   Command="{Binding ViewModel.ClearTransactionCommand}">Clear</ui:Button>
                     </Grid>
 
                     

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -38,7 +38,7 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,16,0,24" VerticalAlignment="Stretch">
+            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,16,0,24" VerticalAlignment="Top">
                 <ui:ListView x:Name="TransactionsList" BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
                               SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                               SelectedItem="{Binding ViewModel.SelectedTransaction}">

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -33,170 +33,87 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
-            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
 
-        <Grid>
+        <ui:Card Grid.Column="0" VerticalAlignment="Top" Margin="0,0,12,0">
+            <StackPanel Grid.Column="0">
+                <ui:ListView MaxHeight="200" ItemsSource="{Binding ViewModel.Accounts}" 
+                                   SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
+                                   SelectedItem="{Binding ViewModel.SelectedAccount}">
+                    <ui:ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Text="{Binding AccountName}" Margin="4"/>
+                                <ui:TextBlock Grid.Column="1" Text="{Binding Total}" Margin="4"/>
+                            </Grid>
+
+                        </DataTemplate>
+                    </ui:ListView.ItemTemplate>
+
+                    <ui:ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Rename" Command="{Binding ViewModel.RenameAccountCommand}" CommandParameter="{StaticResource RenameDialogContent}"/>
+                            <MenuItem Header="Delete Account" Command="{Binding ViewModel.DeleteAccountCommand}"/>
+                        </ContextMenu>
+                    </ui:ListView.ContextMenu>
+                </ui:ListView>
+                <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddTransactionButtonClickCommand}" Appearance="Primary">New Transaction</ui:Button>
+                <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">New Account</ui:Button>
+                <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
+            </StackPanel>
+        </ui:Card>
+
+        <Grid Grid.Column="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
 
 
-            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,0,0,24" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
+            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="12,0,0,24" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
 
-                    <ComboBox Grid.Row="0" x:Name="cmbAccounts" ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
-                      SelectedItem="{Binding ViewModel.SelectedAccount}" Margin="0,0,0,8">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding AccountName}"/>
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-
-                    <ui:ListView Grid.Row="1" x:Name="TransactionsList" BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
+                <ui:ListView x:Name="TransactionsList" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
                                   SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
-                                  SelectedItem="{Binding ViewModel.SelectedTransaction}">
-                        <ui:ListView.ItemTemplate>
-                            <DataTemplate DataType="{x:Type models:Transaction}">
-                                <Grid Margin="0,2,0,2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="1*"/>
-                                        <ColumnDefinition Width="5*"/>
-                                        <ColumnDefinition Width="1*"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto"/>
-                                        <RowDefinition Height="Auto"/>
-                                    </Grid.RowDefinitions>
+                                  SelectedItem="{Binding ViewModel.SelectedTransaction}" VerticalAlignment="Top">
+                    <ui:ListView.ItemTemplate>
+                        <DataTemplate DataType="{x:Type models:Transaction}">
+                            <Grid Margin="0,2,0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="5*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                                    <Controls:MonthDayControl Grid.RowSpan="2" Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" HorizontalAlignment="Left" Margin="16,0,0,0"/>
+                                <Controls:MonthDayControl Grid.RowSpan="2" Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" HorizontalAlignment="Left" Margin="16,0,0,0"/>
 
-                                    <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
-                                    <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
+                                <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
+                                <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
 
-                                    <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" FontWeight="SemiBold"
+                                <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" FontWeight="SemiBold"
                                                   Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0">
-                                        <ui:TextBlock.Style>
-                                            <Style TargetType="ui:TextBlock">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter} }" Value="True">
-                                                        <Setter Property="Foreground" Value="{DynamicResource AccentTextFillColorTertiaryBrush}"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </ui:TextBlock.Style>
-                                    </ui:TextBlock>
-                                </Grid>
-                            </DataTemplate>
-                        </ui:ListView.ItemTemplate>
-                    </ui:ListView>                    
-                </Grid>
+                                    <ui:TextBlock.Style>
+                                        <Style TargetType="ui:TextBlock">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter} }" Value="True">
+                                                    <Setter Property="Foreground" Value="{DynamicResource AccentTextFillColorTertiaryBrush}"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </ui:TextBlock.Style>
+                                </ui:TextBlock>
+                            </Grid>
+                        </DataTemplate>
+                    </ui:ListView.ItemTemplate>
+                </ui:ListView>
 
-            </ui:Card>
-        </Grid>
-
-        <Grid Grid.Column="1" Margin="24,0,0,24">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="1*"/>
-            </Grid.RowDefinitions>
-            <ui:Card VerticalAlignment="Top">
-                <StackPanel Margin="8,0,8,0">
-                    <ui:TextBlock FontTypography="Subtitle" Margin="0,16,0,24">New Transaction</ui:TextBlock>
-                    <ui:TextBlock Margin="0,0,0,4">Transaction type</ui:TextBlock>
-                    <Grid Margin="0,0,0,16">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*"/>
-                            <ColumnDefinition Width="1*"/>
-                        </Grid.ColumnDefinitions>
-                        <RadioButton Grid.Column="1" IsChecked="{Binding ViewModel.NewTransactionIsIncome}">Income</RadioButton>
-                        <RadioButton Grid.Column="0" IsChecked="{Binding ViewModel.NewTransactionIsExpense}">Expense</RadioButton>
-                    </Grid>
-                    <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
-                    <ui:TextBox Margin="0,0,0,16" Text="{Binding Path=ViewModel.NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"/>
-                    <Grid Margin="0,0,0,16">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="135"/>
-                            <ColumnDefinition Width="1*"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="Auto"/>
-                        </Grid.RowDefinitions>
-
-                        <ui:TextBlock Margin="0,0,0,4">Date</ui:TextBlock>
-                        <DatePicker Grid.Row="1" Margin="0,0,4,0" SelectedDateFormat="Short" IsTodayHighlighted="True"
-                                    SelectedDate="{Binding ViewModel.NewTransactionDate}"/>
-                        <ui:TextBlock Grid.Column="1" Grid.Row="0" Margin="4,0,0,4">Payee</ui:TextBlock>
-                        <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0" Text="{Binding ViewModel.NewTransactionPayee}"/>
-                    </Grid>
-                    <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
-                    <ComboBox ItemsSource="{Binding ViewModel.CategoryNames}" Text="{Binding ViewModel.NewTransactionCategory}"/>
-                    <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
-                    <ui:TextBox Margin="0,0,0,24" Text="{Binding ViewModel.NewTransactionMemo}"/>
-                    <Grid Margin="0,0,0,8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="1*"/>
-                            <ColumnDefinition Width="1*"/>
-                        </Grid.ColumnDefinitions>
-                        <ui:Button Grid.Column="0" Appearance="Primary" HorizontalAlignment="Stretch" Margin="0,0,4,0"
-                                   Command="{Binding ViewModel.AddTransactionButtonClickCommand}">Add</ui:Button>
-                        <ui:Button Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,0,0,0"
-                                   Command="{Binding ViewModel.ClearTransactionCommand}">Clear</ui:Button>
-                    </Grid>
-
-                    
-                </StackPanel>
-            </ui:Card>
-
-            <ui:Card Grid.Row="1" VerticalAlignment="Top" Margin="0,24,0,0">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="1*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="1*"/>
-                    </Grid.RowDefinitions>
-                    <ui:TextBlock FontTypography="Subtitle" Margin="0,0,0,8">Accounts</ui:TextBlock>
-                    
-                    <StackPanel Grid.Column="0" Grid.Row="1">
-                        <ui:ListView MaxHeight="200" ItemsSource="{Binding ViewModel.Accounts}" 
-                                     SelectedIndex="{Binding ViewModel.SelectedAccountIndex}">
-                            <ui:ListView.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="1*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <ui:TextBlock Text="{Binding AccountName}" Margin="4"/>
-                                        <ui:TextBlock Grid.Column="1" Text="{Binding Total}" Margin="4"/>
-                                    </Grid>
-                                    
-                                </DataTemplate>
-                            </ui:ListView.ItemTemplate>
-
-                            <ui:ListView.ContextMenu>
-                                <ContextMenu>
-                                    <MenuItem Header="Rename" Command="{Binding ViewModel.RenameAccountCommand}" CommandParameter="{StaticResource RenameDialogContent}"/>
-                                    <MenuItem Header="Delete Account" Command="{Binding ViewModel.DeleteAccountCommand}"/>
-                                </ContextMenu>
-                            </ui:ListView.ContextMenu>
-                        </ui:ListView>
-                    </StackPanel>
-                    
-                    <StackPanel Grid.Column="1" Grid.Row="1" Margin="16,0,0,0">
-                        <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">New Account</ui:Button>
-                        <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
-                    </StackPanel>
-                </Grid>
             </ui:Card>
         </Grid>
     </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -62,9 +62,9 @@
                         </ContextMenu>
                     </ui:ListView.ContextMenu>
                 </ui:ListView>
-                <ui:Button HorizontalAlignment="Stretch" Margin="0,12,0,8" Command="{Binding ViewModel.AddTransactionButtonClickCommand}" Appearance="Primary">New Transaction</ui:Button>
+                <ui:Button HorizontalAlignment="Stretch" Margin="0,12,0,8" Command="{Binding ViewModel.AddTransactionButtonClickCommand}" Appearance="Primary" IsEnabled="{Binding ViewModel.TransactionsEnabled}">New Transaction</ui:Button>
                 <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">New Account</ui:Button>
-                <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
+                <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}" IsEnabled="{Binding ViewModel.TransactionsEnabled}">Transfer</ui:Button>
             </StackPanel>
         </ui:Card>
 

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -19,7 +19,14 @@
       Loaded="Page_Loaded"
       >
     <Page.Resources>
-        <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
+        <ResourceDictionary>
+            <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
+
+            <StackPanel x:Key="RenameDialogContent">
+                <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
+                <TextBox HorizontalAlignment="Stretch"/>
+            </StackPanel>
+        </ResourceDictionary>
     </Page.Resources>
 
     <Grid>
@@ -154,7 +161,8 @@
                     <ui:TextBlock FontTypography="Subtitle" Margin="0,0,0,8">Accounts</ui:TextBlock>
                     
                     <StackPanel Grid.Column="0" Grid.Row="1">
-                        <ui:ListView MaxHeight="200" ItemsSource="{Binding ViewModel.Accounts}">
+                        <ui:ListView MaxHeight="200" ItemsSource="{Binding ViewModel.Accounts}" 
+                                     SelectedIndex="{Binding ViewModel.SelectedAccountIndex}">
                             <ui:ListView.ItemTemplate>
                                 <DataTemplate>
                                     <Grid>
@@ -171,6 +179,7 @@
 
                             <ui:ListView.ContextMenu>
                                 <ContextMenu>
+                                    <MenuItem Header="Rename" Command="{Binding ViewModel.RenameAccountCommand}" CommandParameter="{StaticResource RenameDialogContent}"/>
                                     <MenuItem Header="Delete Account" Command="{Binding ViewModel.DeleteAccountCommand}"/>
                                 </ContextMenu>
                             </ui:ListView.ContextMenu>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -10,7 +10,7 @@
       xmlns:models="clr-namespace:MyMoney.Core.FS.Models;assembly=MyMoney.Core.FS" xmlns:Controls="clr-namespace:MyMoney.Views.Controls" x:Class="MyMoney.Views.Pages.AccountsPage"
       xmlns:helpers="clr-namespace:MyMoney.Helpers"
       mc:Ignorable="d" 
-      d:DesignHeight="450" d:DesignWidth="800"
+      d:DesignHeight="500" d:DesignWidth="800"
       Title="Accounts"
       d:DataContext="{d:DesignInstance {x:Type local:AccountsPage}, IsDesignTimeCreatable=False}"
       ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
@@ -89,6 +89,52 @@
                     </ui:ListView>                    
                 </Grid>
 
+            </ui:Card>
+        </Grid>
+
+        <Grid Grid.Column="1" Margin="24,0,0,24">
+            <ui:Card VerticalAlignment="Top">
+                <StackPanel Margin="8,0,8,0">
+                    <ui:TextBlock FontTypography="Subtitle" Margin="0,16,0,24">New Transaction</ui:TextBlock>
+                    <ui:TextBlock Margin="0,0,0,4">Transaction type</ui:TextBlock>
+                    <Grid Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*"/>
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+                        <RadioButton Grid.Column="1">Income</RadioButton>
+                        <RadioButton Grid.Column="0">Expense</RadioButton>
+                    </Grid>
+                    <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
+                    <ui:NumberBox MaxDecimalPlaces="2" Margin="0,0,0,16"/>
+                    <Grid Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="135"/>
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <ui:TextBlock Margin="0,0,0,4">Date</ui:TextBlock>
+                        <DatePicker Grid.Row="1" Margin="0,0,4,0" SelectedDateFormat="Short" IsTodayHighlighted="True"/>
+                        <ui:TextBlock Grid.Column="1" Grid.Row="0" Margin="4,0,0,4">Payee</ui:TextBlock>
+                        <TextBox Grid.Row="1" Grid.Column="1" Margin="4,0,0,0"/>
+                    </Grid>
+                    <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
+                    <ui:TextBox Margin="0,0,0,24"/>
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*"/>
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+                        <ui:Button Grid.Column="0" Appearance="Primary" HorizontalAlignment="Stretch" Margin="0,0,4,0">Add</ui:Button>
+                        <ui:Button Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,0,0,0">Clear</ui:Button>
+                    </Grid>
+
+                    
+                </StackPanel>
             </ui:Card>
         </Grid>
     </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -62,7 +62,7 @@
                         </ContextMenu>
                     </ui:ListView.ContextMenu>
                 </ui:ListView>
-                <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddTransactionButtonClickCommand}" Appearance="Primary">New Transaction</ui:Button>
+                <ui:Button HorizontalAlignment="Stretch" Margin="0,12,0,8" Command="{Binding ViewModel.AddTransactionButtonClickCommand}" Appearance="Primary">New Transaction</ui:Button>
                 <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">New Account</ui:Button>
                 <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
             </StackPanel>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -171,15 +171,15 @@
 
                             <ui:ListView.ContextMenu>
                                 <ContextMenu>
-                                    <MenuItem Header="Delete Account"/>
+                                    <MenuItem Header="Delete Account" Command="{Binding ViewModel.DeleteAccountCommand}"/>
                                 </ContextMenu>
                             </ui:ListView.ContextMenu>
                         </ui:ListView>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="1" Grid.Row="1" Margin="16,0,0,0">
-                        <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8">New Account</ui:Button>
-                        <ui:Button HorizontalAlignment="Stretch">Transfer</ui:Button>
+                        <ui:Button HorizontalAlignment="Stretch" Margin="0,0,0,8" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">New Account</ui:Button>
+                        <ui:Button HorizontalAlignment="Stretch" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
                     </StackPanel>
                 </Grid>
             </ui:Card>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -24,7 +24,11 @@
             <ColumnDefinition Width="1*"/>
         </Grid.ColumnDefinitions>
 
-        <StackPanel>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
             <ComboBox x:Name="cmbAccounts" ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
                       SelectedItem="{Binding ViewModel.SelectedAccount}">
                 <ComboBox.ItemTemplate>
@@ -34,8 +38,8 @@
                 </ComboBox.ItemTemplate>
             </ComboBox>
 
-            <ui:Card Margin="0,16,0,0">
-                 <ui:ListView BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
+            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,16,0,24" VerticalAlignment="Stretch">
+                <ui:ListView x:Name="TransactionsList" BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
                               SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                               SelectedItem="{Binding ViewModel.SelectedTransaction}">
                     <ui:ListView.ItemTemplate>
@@ -61,10 +65,8 @@
                             </Grid>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>
-                </ui:ListView>                
+                </ui:ListView>
             </ui:Card>
-               
-
-        </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -26,45 +26,54 @@
 
         <Grid>
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
-            <ComboBox x:Name="cmbAccounts" ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
-                      SelectedItem="{Binding ViewModel.SelectedAccount}">
-                <ComboBox.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding AccountName}"/>
-                    </DataTemplate>
-                </ComboBox.ItemTemplate>
-            </ComboBox>
 
-            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,16,0,24" VerticalAlignment="Top">
-                <ui:ListView x:Name="TransactionsList" BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
-                              SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
-                              SelectedItem="{Binding ViewModel.SelectedTransaction}">
-                    <ui:ListView.ItemTemplate>
-                        <DataTemplate DataType="{x:Type models:Transaction}">
-                            <Grid Margin="0,2,0,2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="1*"/>
-                                    <ColumnDefinition Width="5*"/>
-                                    <ColumnDefinition Width="1*"/>
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                </Grid.RowDefinitions>
 
-                                <Controls:MonthDayControl Grid.RowSpan="2" Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" HorizontalAlignment="Left" Margin="16,0,0,0"/>
+            <ui:Card x:Name="TransactionsCard" Grid.Row="1" Margin="0,0,0,0" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
 
-                                <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
-                                <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
+                    <ComboBox Grid.Row="0" x:Name="cmbAccounts" ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
+                      SelectedItem="{Binding ViewModel.SelectedAccount}" Margin="0,0,0,8">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding AccountName}"/>
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
 
-                                <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0"/>
-                            </Grid>
-                        </DataTemplate>
-                    </ui:ListView.ItemTemplate>
-                </ui:ListView>
+                    <ui:ListView Grid.Row="1" x:Name="TransactionsList" BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
+                                  SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
+                                  SelectedItem="{Binding ViewModel.SelectedTransaction}">
+                        <ui:ListView.ItemTemplate>
+                            <DataTemplate DataType="{x:Type models:Transaction}">
+                                <Grid Margin="0,2,0,2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="1*"/>
+                                        <ColumnDefinition Width="5*"/>
+                                        <ColumnDefinition Width="1*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
+                                    </Grid.RowDefinitions>
+
+                                    <Controls:MonthDayControl Grid.RowSpan="2" Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" HorizontalAlignment="Left" Margin="16,0,0,0"/>
+
+                                    <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
+                                    <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
+
+                                    <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,16,0"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ui:ListView.ItemTemplate>
+                    </ui:ListView>                    
+                </Grid>
+
             </ui:Card>
         </Grid>
     </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -33,7 +33,7 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
-            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
         </Grid.ColumnDefinitions>
 
         <ui:Card Grid.Column="0" VerticalAlignment="Top" Margin="0,0,12,0">

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -79,6 +79,12 @@
                 <ui:ListView x:Name="TransactionsList" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
                                   SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                                   SelectedItem="{Binding ViewModel.SelectedTransaction}" VerticalAlignment="Top">
+                    <ui:ListView.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteTransactionCommand}"/>
+                        </ContextMenu>
+                    </ui:ListView.ContextMenu>
+                    
                     <ui:ListView.ItemTemplate>
                         <DataTemplate DataType="{x:Type models:Transaction}">
                             <Grid Margin="0,2,0,2">

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -21,6 +21,7 @@
     <Page.Resources>
         <ResourceDictionary>
             <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
+            <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
 
             <StackPanel x:Key="RenameDialogContent">
                 <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
@@ -117,7 +118,7 @@
                         <RadioButton Grid.Column="0" IsChecked="{Binding ViewModel.NewTransactionIsExpense}">Expense</RadioButton>
                     </Grid>
                     <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
-                    <ui:TextBox Margin="0,0,0,16" Text="{Binding ViewModel.NewTransactionAmount.Value}"/>
+                    <ui:TextBox Margin="0,0,0,16" Text="{Binding Path=ViewModel.NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"/>
                     <Grid Margin="0,0,0,16">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="135"/>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -20,113 +20,51 @@
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="150"/>
+            <ColumnDefinition Width="1*"/>
             <ColumnDefinition Width="1*"/>
         </Grid.ColumnDefinitions>
 
         <StackPanel>
-            <ui:Card Grid.Column="0" VerticalAlignment="Top" Margin="0,0,8,8">
-                <ui:ListView ItemsSource="{Binding ViewModel.Accounts}" SelectedItem="{Binding ViewModel.SelectedAccount, Mode=TwoWay}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}">
+            <ComboBox ItemsSource="{Binding ViewModel.Accounts}" SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
+                      SelectedItem="{Binding ViewModel.SelectedAccount}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding AccountName}"/>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
+            <ui:Card Margin="0,16,0,0">
+                 <ui:ListView BorderThickness="1" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
+                              SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
+                              SelectedItem="{Binding ViewModel.SelectedTransaction}">
                     <ui:ListView.ItemTemplate>
-                        <DataTemplate DataType="{x:Type models:Account}">
-                            <TextBlock Text="{Binding AccountName}" Margin="0,5,0,5"/>
+                        <DataTemplate>
+                            <Grid Margin="0,2,0,2">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="5*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+
+                                <ui:TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Date.Day}" FontSize="18" FontWeight="SemiBold"/>
+                                <ui:TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding MonthAbbreviated}"/>
+
+                                <ui:TextBlock Grid.Row="0" Grid.Column="1" FontSize="16" HorizontalAlignment="Left" Text="{Binding Payee}"/>
+                                <ui:TextBlock Grid.Row="1" Grid.Column="1" HorizontalAlignment="Left" Text="{Binding Category}"/>
+
+                                <ui:TextBlock Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" FontSize="24" Text="{Binding AmountFormatted}" HorizontalAlignment="Right"/>
+                            </Grid>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>
-
-                    <ui:ListView.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteAccountCommand}"/>
-                        </ContextMenu>
-                    </ui:ListView.ContextMenu>
-
-                    <ui:ListView.InputBindings>
-                        <KeyBinding 
-                            Key="Delete" Command="{Binding ViewModel.DeleteAccountCommand}"/>
-                    </ui:ListView.InputBindings>
-                </ui:ListView>
+                </ui:ListView>                
             </ui:Card>
+               
 
-            <ui:Button HorizontalAlignment="Stretch" Margin="0,8,8,4" Command="{Binding ViewModel.AddNewAccountButtonClickCommand}">Add Account</ui:Button>
-            <ui:Button HorizontalAlignment="Stretch" Margin="0,4,8,8" Command="{Binding ViewModel.TransferBetweenAccountsCommand}">Transfer</ui:Button>
         </StackPanel>
-
-
-        <Grid Grid.Column="1" Margin="8,0,0,0">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-
-            <ui:Card x:Name="TransactionsCard" Grid.Row="0" VerticalAlignment="Stretch">
-                <ui:ListView x:Name="TransactionsList" ItemsSource="{Binding ViewModel.SelectedAccountTransactions}" 
-                             SelectedItem="{Binding ViewModel.SelectedTransaction, Mode=TwoWay}" 
-                             SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}" 
-                             MaxHeight="{Binding ViewModel.TransactionsMaxHeight}" 
-                             VerticalAlignment="Top" SizeChanged="TransactionsList_SizeChanged" 
-                             BorderThickness="0">
-                    <ui:ListView.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteTransactionCommand}"/>
-                        </ContextMenu>
-                    </ui:ListView.ContextMenu>
-
-                    <ui:ListView.InputBindings>
-                        <KeyBinding 
-                            Key="Delete" Command="{Binding ViewModel.DeleteTransactionCommand}"/>
-                    </ui:ListView.InputBindings>
-
-                    <ui:ListView.View>
-                        <ui:GridView>
-                            <ui:GridViewColumn Header="Date" Width="125" DisplayMemberBinding="{Binding DateFormatted}"/>
-                            <ui:GridViewColumn Header="Payee" Width="200" DisplayMemberBinding="{Binding Payee}"/>
-                            <ui:GridViewColumn Header="Category" Width="125" DisplayMemberBinding="{Binding Category}"/>
-                            <ui:GridViewColumn Header="Memo" Width="200" DisplayMemberBinding="{Binding Memo}"/>
-                            <ui:GridViewColumn Header="Spend" Width="100" DisplayMemberBinding="{Binding Spend}"/>
-                            <ui:GridViewColumn Header="Receive" Width="100" DisplayMemberBinding="{Binding Receive}"/>
-                            <ui:GridViewColumn Header="Balance" Width="100" DisplayMemberBinding="{Binding Balance}"/>
-                        </ui:GridView>
-                    </ui:ListView.View>
-                </ui:ListView>
-            </ui:Card>
-
-            <StackPanel Grid.Row="1" Margin="0,24,0,24">
-
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="135"/>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="100"/>
-                        <ColumnDefinition Width="100"/>
-                    </Grid.ColumnDefinitions>
-
-                    <Label Grid.Row="0" Grid.Column="0">Date</Label>
-                    <Label Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Margin="4,0,0,0">Payee</Label>
-                    <DatePicker Grid.Row="1" Grid.Column="0" IsTodayHighlighted="True" Margin="0,0,4,0" SelectedDateFormat="Short" IsEnabled="{Binding ViewModel.IsInputEnabled}" SelectedDate="{Binding ViewModel.NewTransactionDate}"/>
-                    <ui:TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Margin="4,0,4,0" IsEnabled="{Binding ViewModel.IsInputEnabled}" Text="{Binding ViewModel.NewTransactionPayee}"/>
-
-                    <Label Grid.Row="2" Grid.Column="1" Margin="4,0,0,0">Category</Label>
-                    <Label Grid.Row="2" Grid.Column="2" Margin="4,0,0,0">Memo</Label>
-                    <Label Grid.Row="0" Grid.Column="3" Margin="4,0,0,0">Spend</Label>
-                    <Label Grid.Row="0" Grid.Column="4" Margin="4,0,0,0">Receive</Label>
-
-                    <ComboBox Grid.Row="3" Grid.Column="1" Margin="4,0,4,0" IsEnabled="{Binding ViewModel.IsInputEnabled}" Text="{Binding ViewModel.NewTransactionCategory}" ItemsSource="{Binding ViewModel.CategoryNames}"/>
-                    <ui:TextBox Grid.Row="3" Grid.Column="2" Margin="4,0,4,0" IsEnabled="{Binding ViewModel.IsInputEnabled}" Text="{Binding ViewModel.NewTransactionMemo}"/>
-                    <ui:TextBox x:Name="txtSpend" Grid.Row="1" Grid.Column="3" Margin="4,0,4,0" IsEnabled="{Binding ViewModel.IsInputEnabled}" Text="{Binding ViewModel.NewTransactionSpend.Value}"/>
-                    <ui:TextBox Grid.Row="1" Grid.Column="4" Margin="4,0,0,0" IsEnabled="{Binding ViewModel.IsInputEnabled}" Text="{Binding ViewModel.NewTransactionReceive.Value}"/>
-
-                    <ui:Button Grid.Row="3" Grid.Column="3" Grid.ColumnSpan="2" HorizontalAlignment="Stretch" Margin="4,0,0,0" VerticalAlignment="Stretch" IsEnabled="{Binding ViewModel.IsInputEnabled}" Click="AddTransaction_Click" Content="{Binding ViewModel.AddTransactionButtonText}" Appearance="Primary"/>
-                </Grid>
-                
-                
-            </StackPanel>
-        </Grid>
     </Grid>
 </Page>

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -20,11 +20,6 @@ namespace MyMoney.Views.Pages
             InitializeComponent();
 
             Application.Current.MainWindow.SizeChanged += MainWindow_SizeChanged;
-
-            if (cmbAccounts.Items.Count > 0)
-            {
-                cmbAccounts.SelectedIndex = 0;
-            }
         }
 
         private void MainWindow_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -34,7 +29,7 @@ namespace MyMoney.Views.Pages
 
         private void UpdateTransactionsMaxHeight()
         {
-            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 270;
+            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 220;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -27,6 +27,8 @@ namespace MyMoney.Views.Pages
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel.OnPageNavigatedTo();
+
+            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 300;
         }
     }
 }

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -22,50 +22,6 @@ namespace MyMoney.Views.Pages
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel.OnPageNavigatedTo();
-
-            UpdateListViewMaxHeight();
-
-            ScrollTransactionsToBottom();
-        }
-
-        private void AddTransaction_Click(object sender, RoutedEventArgs e)
-        {
-            ViewModel.AddTransactionButtonClickCommand.Execute(null);
-
-            ScrollTransactionsToBottom();
-        }
-
-        private void ScrollTransactionsToBottom()
-        {
-            TransactionsList.SelectedIndex = TransactionsList.Items.Count - 1;
-            TransactionsList.ScrollIntoView(TransactionsList.SelectedItem);
-            TransactionsList.SelectedIndex = -1;
-        }
-
-        private void UpdateListViewMaxHeight()
-        {
-            double cardHeight = TransactionsCard.ActualHeight;
-            ViewModel.TransactionsMaxHeight = cardHeight - 36;
-        }
-
-        private void TransactionsList_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            // Update the memo gridview column width
-            if (TransactionsList.View is Wpf.Ui.Controls.GridView gridView) 
-            { 
-                double totalWidth = TransactionsList.ActualWidth;
-                double fixedWidth = 0;
-
-                foreach (var column in gridView.Columns)
-                {
-                    fixedWidth += column.Width;
-                }
-
-                fixedWidth -= gridView.Columns[3].Width;
-
-                double lastColumnWidth = totalWidth - fixedWidth - SystemParameters.VerticalScrollBarWidth - 10; 
-                gridView.Columns[3].Width = lastColumnWidth > 0 ? lastColumnWidth : 0; 
-            }
         }
     }
 }

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -17,6 +17,11 @@ namespace MyMoney.Views.Pages
             DataContext = this;
 
             InitializeComponent();
+
+            if (cmbAccounts.Items.Count > 0)
+            {
+                cmbAccounts.SelectedIndex = 0;
+            }
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MyMoney.ViewModels.Pages;
 using System.Windows.Controls;
+using Wpf.Ui;
 using Wpf.Ui.Controls;
 
 namespace MyMoney.Views.Pages

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -18,17 +18,29 @@ namespace MyMoney.Views.Pages
 
             InitializeComponent();
 
+            Application.Current.MainWindow.SizeChanged += MainWindow_SizeChanged;
+
             if (cmbAccounts.Items.Count > 0)
             {
                 cmbAccounts.SelectedIndex = 0;
             }
         }
 
+        private void MainWindow_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            UpdateTransactionsMaxHeight();
+        }
+
+        private void UpdateTransactionsMaxHeight()
+        {
+            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 270;
+        }
+
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel.OnPageNavigatedTo();
 
-            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 300;
+            UpdateTransactionsMaxHeight();
         }
     }
 }

--- a/MyMoney/Views/Windows/MainWindow.xaml
+++ b/MyMoney/Views/Windows/MainWindow.xaml
@@ -52,7 +52,8 @@
             MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
             OpenPaneLength="310"
             PaneDisplayMode="Left"
-            TitleBar="{Binding ElementName=TitleBar, Mode=OneWay}">
+            TitleBar="{Binding ElementName=TitleBar, Mode=OneWay}"
+            ScrollViewer.IsDeferredScrollingEnabled="False">
             <ui:NavigationView.Header>
                 <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
             </ui:NavigationView.Header>
@@ -67,7 +68,7 @@
             </ui:NavigationView.AutoSuggestBox>
             <ui:NavigationView.ContentOverlay>
                 <Grid>
-                    <ui:SnackbarPresenter x:Name="SnackbarPresenter" />
+                    <ui:SnackbarPresenter x:Name="SnackbarPresenter" ScrollViewer.CanContentScroll="False"/>
                 </Grid>
             </ui:NavigationView.ContentOverlay>
         </ui:NavigationView>


### PR DESCRIPTION
The accounts page now has a new look. Here are the main changes:

- No longer trying to replicate a checkbook register interface
- Transactions are displayed in a narrower list with only the basic information showing
- New interface for creating transactions
- Transactions are sorted by date, instead of in the order they were entered
- The balance will not be shown on each transaction
