### PR TITLE
Load future budget into list when it is created

### DIFF
--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -497,6 +497,9 @@ namespace MyMoney.ViewModels.Pages
                         break;
                     }
                 }
+
+                // Update budget lists
+                UpdateBudgetLists();
             }
         }
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -487,19 +487,33 @@ namespace MyMoney.ViewModels.Pages
 
                 // Add to list of budgets
                 Budgets.Add(newBudget);
-                
+
+                // Update budget lists
+                UpdateBudgetLists();
+
                 // Set as current budget
                 foreach (var item in Budgets)
                 {
                     if (item.BudgetTitle == budgetTitle)
                     {
                         CurrentBudget = item;
+
+                        // Select listview item for this budget item
+                        if (item.BudgetDate.Month == DateTime.Now.Month)
+                        {
+                            CurrentBudgetsSelectedIndex = 0;
+                            OldBudgetsSelectedIndex = -1;
+                            FutureBudgetsSelectedIndex = -1;
+                        }
+                        else
+                        {
+                            CurrentBudgetsSelectedIndex = -1;
+                            OldBudgetsSelectedIndex = -1;
+                            FutureBudgetsSelectedIndex = 0;
+                        }
                         break;
                     }
                 }
-
-                // Update budget lists
-                UpdateBudgetLists();
             }
         }
 


### PR DESCRIPTION
When a new budget is created, it is now added to the new budgets list immediately, instead of waiting for the page to refresh. The newly created budget is also selected. Fixes #109 