### PR TITLE
Use month abbreviations for 12 month income vs expense chart

### DIFF
--- a/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
+++ b/MyMoney.Core/Reports/IncomeExpense12MonthCalculator.cs
@@ -22,7 +22,7 @@ namespace MyMoney.Core.Reports
             for (int i = 11; i >= 0; i--) 
             { 
                 DateTime targetDate = currentDate.AddMonths(-i); 
-                string monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(targetDate.Month); 
+                string monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetAbbreviatedMonthName(targetDate.Month); 
                 monthNames.Add(monthName);
             } 
             


### PR DESCRIPTION
The month names on the labels for the 12 month income vs expense chart on the reports page were running into each other when the window was too small. This replaces them with month abbreviations. Closes #123 