### PR TITLE
Prevent duplicate budgets from being created

### DIFF
--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -544,6 +544,21 @@ namespace MyMoney.ViewModels.Pages
                 newBudget.BudgetTitle = budgetTitle;
                 newBudget.BudgetDate = Convert.ToDateTime(budgetTitle);
 
+                // make sure this budget doesn't exist already
+                foreach (var budget in Budgets)
+                {
+                    if (budget.BudgetDate == newBudget.BudgetDate)
+                    {
+                        Wpf.Ui.Controls.MessageBox msgBox = new()
+                        {
+                            Title = "Budget Already Exists",
+                            Content = "Could not create a new budget because a budget for the selected month already exists.",
+                        };
+                        await msgBox.ShowDialogAsync();
+                        return;
+                    }
+                }
+
                 // Copy over categories if box is checked
                 if (viewModel.UseLastMonthsBudget && CurrentBudget != null)
                 {

--- a/MyMoney/Views/ContentDialogs/NewBudgetDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewBudgetDialog.xaml
@@ -15,7 +15,7 @@
     <StackPanel>
         <ui:TextBlock Margin="0,0,0,12">Budget for:</ui:TextBlock>
         <ComboBox x:Name="cmbBudgetDates" ItemsSource="{Binding AvailableBudgetDates}" Margin="0,0,0,16"
-                          SelectedIndex="{Binding SelectedDateIndex}" SelectedItem="{Binding ViewModel.SelectedDate}"/>
+                          SelectedIndex="{Binding SelectedDateIndex}" SelectedItem="{Binding SelectedDate}"/>
 
         <CheckBox IsChecked="{Binding UseLastMonthsBudget}">Start with previous month's budget</CheckBox>
     </StackPanel>


### PR DESCRIPTION
Prevent the user from creating a budget for a month that already has a budget. Fixes #122 