### PR TITLE
Fix window startup state

### DIFF
--- a/MyMoney/Views/Windows/MainWindow.xaml
+++ b/MyMoney/Views/Windows/MainWindow.xaml
@@ -20,9 +20,10 @@
     WindowBackdropType="Mica"
     WindowCornerPreference="Round"
     WindowStartupLocation="CenterScreen"
-    mc:Ignorable="d" WindowState="Maximized"
+    mc:Ignorable="d" WindowState="Normal"
     MinWidth="1000"
-    MinHeight="500">
+    MinHeight="500"
+    Loaded="FluentWindow_Loaded">
     <ui:FluentWindow.InputBindings>
         <KeyBinding
             Key="F"

--- a/MyMoney/Views/Windows/MainWindow.xaml.cs
+++ b/MyMoney/Views/Windows/MainWindow.xaml.cs
@@ -87,5 +87,10 @@ namespace MyMoney.Views.Windows
         {
             throw new NotImplementedException();
         }
+
+        private void FluentWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            WindowState = WindowState.Maximized;
+        }
     }
 }


### PR DESCRIPTION
The main window has been starting up slightly too big to fit onto the screen. This starts the window up not maximized, and then maximizes it from the code.