### PR TITLE
Fix currency converter to accept dollar signs

### DIFF
--- a/MyMoney/Helpers/CurrencyConverter.cs
+++ b/MyMoney/Helpers/CurrencyConverter.cs
@@ -17,9 +17,16 @@ namespace MyMoney.Helpers
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            if (value is string text && decimal.TryParse(text, out decimal result))
+            if (value is string text)
             {
-                return new Currency(result);
+                string amount = text;
+                if (text.StartsWith('$'))
+                {
+                    amount = text.Substring(1);
+                }
+
+                if (decimal.TryParse(amount, out decimal result))
+                    return new Currency(result);
             }
             return DependencyProperty.UnsetValue;
         }


### PR DESCRIPTION
Dollar signs were not accepted by the currency converter, so that when editing a dollar amount in a textbox, if the dollar sign was present the amount was not accepted. Fixes #137 