### PR TITLE
Implement backup functionality

### DIFF
--- a/MyMoney.Core/Database/DatabaseBackup.cs
+++ b/MyMoney.Core/Database/DatabaseBackup.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+
+namespace MyMoney.Core.Database
+{
+    public static class DatabaseBackup
+    {
+        public static void WriteDatabaseBackup(string filePath)
+        {
+            // Get the database location
+            string location = DataFileLocationGetter.GetDataFilePath();
+
+            // Copy the datafile to the new file path, overwriting the file if it already exists
+            File.Copy(location, filePath, true);
+        }
+
+        public static void RestoreDatabaseBackup(string backupPath)
+        {
+            // Get the location we want to put the backup
+            string location = DataFileLocationGetter.GetDataFilePath();
+
+            File.Copy(backupPath, location, true);
+        }
+    }
+}

--- a/MyMoney/Helpers/EnumToBooleanConverter.cs
+++ b/MyMoney/Helpers/EnumToBooleanConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using MyMoney.ViewModels.Pages;
+using System.Globalization;
 using System.Windows.Data;
 using Wpf.Ui.Appearance;
 

--- a/MyMoney/Helpers/RadioButtonConverters/BackupModeRadioButtonGroup.cs
+++ b/MyMoney/Helpers/RadioButtonConverters/BackupModeRadioButtonGroup.cs
@@ -1,0 +1,8 @@
+﻿namespace MyMoney.Helpers.RadioButtonConverters
+{
+    public enum BackupModeRadioButtonGroup
+    {
+        Manual,
+        Automatic,
+    }
+}

--- a/MyMoney/Helpers/RadioButtonConverters/RadioButtonEnumToBooleanConverter.cs
+++ b/MyMoney/Helpers/RadioButtonConverters/RadioButtonEnumToBooleanConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace MyMoney.Helpers.RadioButtonConverters
+{
+    public class RadioButtonEnumToBooleanConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return value?.Equals(parameter) ?? false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (bool)value ? parameter : Binding.DoNothing;
+        }
+    }
+}

--- a/MyMoney/ViewModels/Pages/SettingsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/SettingsViewModel.cs
@@ -2,6 +2,8 @@
 using Wpf.Ui.Abstractions.Controls;
 using MyMoney.Core.Database;
 using MyMoney.Helpers.RadioButtonConverters;
+using Microsoft.Win32;
+using System.IO;
 
 namespace MyMoney.ViewModels.Pages
 {
@@ -29,6 +31,19 @@ namespace MyMoney.ViewModels.Pages
             OneMonth = 3,
             ThreeMonths = 4,
             Forever = 5,
+        }
+
+        public int BackupDurationIndex
+        {
+            get
+            {
+                return (int)BackupDuration;
+            }
+            set
+            {
+                BackupDuration = (BackupStorageDuration)value;
+                OnPropertyChanged(nameof(BackupDurationIndex));
+            }
         }
 
         [ObservableProperty]
@@ -107,7 +122,14 @@ namespace MyMoney.ViewModels.Pages
         [RelayCommand]
         private void BackupNow()
         {
-
+            // Show a save file dialog to get the location of the backup
+            SaveFileDialog saveFileDialog = new();
+            saveFileDialog.Filter = "MyMoney Databases|*.db";
+            saveFileDialog.Title = "Choose backup location...";
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                DatabaseBackup.WriteDatabaseBackup(saveFileDialog.FileName);
+            }
         }
 
     }

--- a/MyMoney/ViewModels/Pages/SettingsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/SettingsViewModel.cs
@@ -1,11 +1,18 @@
 ﻿using Wpf.Ui.Appearance;
 using Wpf.Ui.Abstractions.Controls;
 using MyMoney.Core.Database;
+using MyMoney.Helpers.RadioButtonConverters;
 
 namespace MyMoney.ViewModels.Pages
 {
     public partial class SettingsViewModel : ObservableObject, INavigationAware
     {
+        [ObservableProperty]
+        private BackupModeRadioButtonGroup backupMode = BackupModeRadioButtonGroup.Manual;
+
+        [ObservableProperty]
+        private string _backupLocation = "";
+
         private bool _isInitialized;
 
         [ObservableProperty]
@@ -13,6 +20,19 @@ namespace MyMoney.ViewModels.Pages
 
         [ObservableProperty]
         private ApplicationTheme _currentTheme = ApplicationTheme.Unknown;
+
+        public enum BackupStorageDuration
+        {
+            FourDays = 0,
+            OneWeek = 1,
+            TwoWeeks = 2,
+            OneMonth = 3,
+            ThreeMonths = 4,
+            Forever = 5,
+        }
+
+        [ObservableProperty]
+        private BackupStorageDuration _backupDuration = BackupStorageDuration.OneWeek;
 
         private void InitializeViewModel()
         {
@@ -83,5 +103,12 @@ namespace MyMoney.ViewModels.Pages
         {
             return Task.CompletedTask;
         }
+
+        [RelayCommand]
+        private void BackupNow()
+        {
+
+        }
+
     }
 }

--- a/MyMoney/Views/Pages/SettingsPage.xaml
+++ b/MyMoney/Views/Pages/SettingsPage.xaml
@@ -52,21 +52,24 @@
             Margin="0,12,0,0"
             GroupName="BackupMode"
             Content="Manual" 
+            Command="{Binding ViewModel.SaveBackupSettingsCommand}"
             IsChecked="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Manual}}"/>
         <RadioButton
             Margin="0,8,0,0"
             GroupName="BackupMode"
             Content="Automatic"
+            Command="{Binding ViewModel.SaveBackupSettingsCommand}"
             IsChecked="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Automatic}}"/>
         <StackPanel IsEnabled="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Automatic}}">
             <TextBlock Margin="0,12,0,0" Text="Backup location:"/>
             <WrapPanel Margin="0,8,0,0">
-                <ui:TextBox Width="400" Text="{Binding ViewModel.BackupLocation}"/>
-                <ui:Button Margin="4,0,0,0" Content="..." VerticalAlignment="Stretch"/>
+                <ui:TextBox Width="400" Text="{Binding ViewModel.BackupLocation}" IsReadOnly="True"/>
+                <ui:Button Margin="4,0,0,0" Content="..." VerticalAlignment="Stretch" Command="{Binding ViewModel.ChooseAutomaticBackupLocationCommand}"/>
             </WrapPanel>
 
             <TextBlock Margin="0,12,0,0" Text="Keep automatic backups for:"/>
-            <ComboBox Margin="0,8,0,0" HorizontalAlignment="Left" SelectedIndex="{Binding ViewModel.BackupDurationIndex}">
+            <ComboBox Margin="0,8,0,0" HorizontalAlignment="Left" SelectedIndex="{Binding ViewModel.BackupDurationIndex}"
+                      SelectionChanged="ComboBox_SelectionChanged">
                 <ComboBoxItem Content="4 days"/>
                 <ComboBoxItem Content="1 week" IsSelected="True"/>
                 <ComboBoxItem Content="2 weeks"/>

--- a/MyMoney/Views/Pages/SettingsPage.xaml
+++ b/MyMoney/Views/Pages/SettingsPage.xaml
@@ -75,7 +75,8 @@
                 <ComboBoxItem Content="Forever"/>
             </ComboBox>
         </StackPanel>
-        <ui:Button Margin="0,12,0,0" Content="Backup Now" Command="{Binding ViewModel.BackupNowCommand}"/>
+        <ui:Button Margin="0,12,0,0" Content="Backup Now..." Command="{Binding ViewModel.BackupNowCommand}"/>
+        <ui:Button Margin="0,12,0,0" Content="Restore From Backup..." Command="{Binding ViewModel.RestoreFromBackupCommand}"/>
 
         <TextBlock
             Margin="0,24,0,0"

--- a/MyMoney/Views/Pages/SettingsPage.xaml
+++ b/MyMoney/Views/Pages/SettingsPage.xaml
@@ -66,7 +66,7 @@
             </WrapPanel>
 
             <TextBlock Margin="0,12,0,0" Text="Keep automatic backups for:"/>
-            <ComboBox Margin="0,8,0,0" HorizontalAlignment="Left" SelectedIndex="{Binding ViewModel.BackupDuration}">
+            <ComboBox Margin="0,8,0,0" HorizontalAlignment="Left" SelectedIndex="{Binding ViewModel.BackupDurationIndex}">
                 <ComboBoxItem Content="4 days"/>
                 <ComboBoxItem Content="1 week" IsSelected="True"/>
                 <ComboBoxItem Content="2 weeks"/>

--- a/MyMoney/Views/Pages/SettingsPage.xaml
+++ b/MyMoney/Views/Pages/SettingsPage.xaml
@@ -4,13 +4,14 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="clr-namespace:MyMoney.Helpers"
+    xmlns:rbhelpers="clr-namespace:MyMoney.Helpers.RadioButtonConverters"
     xmlns:local="clr-namespace:MyMoney.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="SettingsPage"
     d:DataContext="{d:DesignInstance local:SettingsPage,
                                      IsDesignTimeCreatable=False}"
-    d:DesignHeight="450"
+    d:DesignHeight="600"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -18,6 +19,7 @@
     mc:Ignorable="d">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+        <rbhelpers:RadioButtonEnumToBooleanConverter x:Key="RadioButtonEnumToBooleanConverter"/>
     </Page.Resources>
 
     <StackPanel>
@@ -40,6 +42,40 @@
             Content="Dark"
             GroupName="themeSelect"
             IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
+
+        <TextBlock
+            Margin="0,24,0,0"
+            FontSize="20"
+            FontWeight="Medium"
+            Text="Backups"/>
+        <RadioButton
+            Margin="0,12,0,0"
+            GroupName="BackupMode"
+            Content="Manual" 
+            IsChecked="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Manual}}"/>
+        <RadioButton
+            Margin="0,8,0,0"
+            GroupName="BackupMode"
+            Content="Automatic"
+            IsChecked="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Automatic}}"/>
+        <StackPanel IsEnabled="{Binding ViewModel.BackupMode, Converter={StaticResource RadioButtonEnumToBooleanConverter}, ConverterParameter={x:Static rbhelpers:BackupModeRadioButtonGroup.Automatic}}">
+            <TextBlock Margin="0,12,0,0" Text="Backup location:"/>
+            <WrapPanel Margin="0,8,0,0">
+                <ui:TextBox Width="400" Text="{Binding ViewModel.BackupLocation}"/>
+                <ui:Button Margin="4,0,0,0" Content="..." VerticalAlignment="Stretch"/>
+            </WrapPanel>
+
+            <TextBlock Margin="0,12,0,0" Text="Keep automatic backups for:"/>
+            <ComboBox Margin="0,8,0,0" HorizontalAlignment="Left" SelectedIndex="{Binding ViewModel.BackupDuration}">
+                <ComboBoxItem Content="4 days"/>
+                <ComboBoxItem Content="1 week" IsSelected="True"/>
+                <ComboBoxItem Content="2 weeks"/>
+                <ComboBoxItem Content="1 month"/>
+                <ComboBoxItem Content="3 months"/>
+                <ComboBoxItem Content="Forever"/>
+            </ComboBox>
+        </StackPanel>
+        <ui:Button Margin="0,12,0,0" Content="Backup Now" Command="{Binding ViewModel.BackupNowCommand}"/>
 
         <TextBlock
             Margin="0,24,0,0"

--- a/MyMoney/Views/Pages/SettingsPage.xaml.cs
+++ b/MyMoney/Views/Pages/SettingsPage.xaml.cs
@@ -14,5 +14,10 @@ namespace MyMoney.Views.Pages
 
             InitializeComponent();
         }
+
+        private void ComboBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            ViewModel.SaveBackupSettingsCommand.Execute(null);
+        }
     }
 }

--- a/MyMoney/Views/Windows/MainWindow.xaml
+++ b/MyMoney/Views/Windows/MainWindow.xaml
@@ -23,7 +23,8 @@
     mc:Ignorable="d" WindowState="Normal"
     MinWidth="1000"
     MinHeight="500"
-    Loaded="FluentWindow_Loaded">
+    Loaded="FluentWindow_Loaded"
+    Closing="FluentWindow_Closing">
     <ui:FluentWindow.InputBindings>
         <KeyBinding
             Key="F"

--- a/MyMoney/Views/Windows/MainWindow.xaml.cs
+++ b/MyMoney/Views/Windows/MainWindow.xaml.cs
@@ -1,4 +1,10 @@
-﻿using MyMoney.ViewModels.Windows;
+﻿using MyMoney.Core.Database;
+using MyMoney.Helpers.RadioButtonConverters;
+using MyMoney.ViewModels.Pages;
+using MyMoney.ViewModels.Windows;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
 using Wpf.Ui;
 using Wpf.Ui.Abstractions;
 using Wpf.Ui.Appearance;
@@ -91,6 +97,108 @@ namespace MyMoney.Views.Windows
         private void FluentWindow_Loaded(object sender, RoutedEventArgs e)
         {
             WindowState = WindowState.Maximized;
+        }
+
+        private void FluentWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // Check settings to see if we need to do a backup
+            var databaseReader = new DatabaseReader();
+            var settingsDict = databaseReader.GetSettingsDictionary("ApplicationSettings");
+
+            BackupModeRadioButtonGroup BackupMode = BackupModeRadioButtonGroup.Manual;
+            string BackupLocation = "";
+            SettingsViewModel.BackupStorageDuration BackupStorageDuration = SettingsViewModel.BackupStorageDuration.OneWeek;
+
+            // Extract the settings values
+            if (settingsDict.TryGetValue("BackupMode", out string? backupMode))
+            {
+                try
+                {
+                    BackupMode = (BackupModeRadioButtonGroup)Convert.ToInt32(backupMode);
+                }
+                catch { /* If we can't load a setting, ignore it */ }
+            }
+
+            if (settingsDict.TryGetValue("BackupLocation", out string? backupLocation))
+            {
+                BackupLocation = backupLocation;
+            }
+
+            if (settingsDict.TryGetValue("BackupStorageDuration", out string? backupStorageDuration))
+            {
+                try
+                {
+                    BackupStorageDuration = (SettingsViewModel.BackupStorageDuration)Convert.ToInt32(backupStorageDuration);
+                }
+                catch { /* If we can't load a setting, ignore it */ }
+            }
+
+            // Write backup
+            if (BackupMode == BackupModeRadioButtonGroup.Automatic && backupLocation != "")
+            {
+                // Backup
+                DatabaseBackup.WriteDatabaseBackup(Path.Combine(BackupLocation, $"mymoney-database-backup-{DateTime.Now.ToString("MM-dd-yyyy")}.db"));
+
+                // Clear any old backups
+
+                // Get all *.db files in the backup directory
+                var filesInBackupDir = Directory.EnumerateFiles(BackupLocation, "*.db");
+                var regex = new Regex(@"mymoney-database-backup-(\d{2})-(\d{2})-(\d{4})\.db");
+
+                foreach (var file in filesInBackupDir)
+                {
+                    var filename = Path.GetFileName(file);
+                    var match = regex.Match(filename);
+                    if (match.Success)
+                    {
+                        var month = int.Parse(match.Groups[1].Value);
+                        var day = int.Parse(match.Groups[2].Value);
+                        var year = int.Parse(match.Groups[3].Value);
+
+                        if (DateTime.TryParseExact(
+                            $"{year}-{month:D2}-{day:D2}",
+                            "yyyy-MM-dd",
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.None,
+                            out DateTime backupDate))
+                        {
+                            int daysToKeep = 0;
+
+                            switch (BackupStorageDuration)
+                            {
+                                case SettingsViewModel.BackupStorageDuration.FourDays:
+                                    daysToKeep = 4;
+                                    break;
+                                case SettingsViewModel.BackupStorageDuration.OneWeek:
+                                    daysToKeep = 7;
+                                    break;
+                                case SettingsViewModel.BackupStorageDuration.TwoWeeks:
+                                    daysToKeep = 14;
+                                    break;
+                                case SettingsViewModel.BackupStorageDuration.OneMonth:
+                                    daysToKeep = 30;
+                                    break;
+                                case SettingsViewModel.BackupStorageDuration.ThreeMonths:
+                                    daysToKeep = 90;
+                                    break;
+                                case SettingsViewModel.BackupStorageDuration.Forever:
+                                    return;
+                                default:
+                                    break;
+                            }
+
+                            if (backupDate < DateTime.Today.AddDays(-daysToKeep))
+                            {
+                                try
+                                {
+                                    File.Delete(file);
+                                }
+                                catch { /* Fail silently, it's not important that the file is deleted*/ }
+                                }
+                            }
+                        }
+                    }
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #144 

Provides settings for manual or automatic backups to any file location the user chooses. Manual backups can be triggered by the "Backup Now" button in settings. Automatic backups happen when the application is closing. If there is already a backup saved for the current day, it is overwritten. Backups are automatically deleted after the period of time the user chooses in settings. A backup can be restored from the settings page as well.