### PR TITLE
Implement budget savings categories

### DIFF
--- a/MyMoney.Core/Database/BudgetCollection.cs
+++ b/MyMoney.Core/Database/BudgetCollection.cs
@@ -14,7 +14,7 @@ namespace MyMoney.Core.Database
         /// <summary>
         /// A list of the budgets currently in the database
         /// </summary>
-        public List<Budget> Budgets { get; } = [];
+        public List<Budget> Budgets { get; set; } = [];
 
         public BudgetCollection(IDatabaseReader databaseReader)
         {
@@ -42,6 +42,14 @@ namespace MyMoney.Core.Database
         }
 
         /// <summary>
+        /// Save the budgets collection to the database
+        /// </summary>
+        public void SaveBudgetCollection()
+        {
+            DatabaseWriter.WriteCollection(BudgetCollectionName, Budgets);
+        }
+
+        /// <summary>
         /// Get the budget for the current month
         /// </summary>
         /// <returns>A Budget for the current month</returns>
@@ -56,6 +64,27 @@ namespace MyMoney.Core.Database
             var budget = Budgets.FirstOrDefault(budget => budget.BudgetTitle == GetCurrentBudgetName());
             return budget ?? throw new BudgetNotFoundException("No budget exists for current month");
 
+        }
+
+        /// <summary>
+        /// Get the index of the budget for the current month
+        /// </summary>
+        /// <returns>The index of the budget for the current month</returns>
+        /// <exception cref="BudgetNotFoundException">Throws this when no budget for this month is found</exception>
+        public int GetCurrentBudgetIndex()
+        {
+            if (!DoesCurrentBudgetExist())
+            {
+                throw new BudgetNotFoundException("No budget exists for current month");
+            }
+
+            for (int i = 0; i < Budgets.Count; i++)
+            {
+                if (Budgets[i].BudgetTitle == GetCurrentBudgetName())
+                    return i;
+            }
+
+            throw new BudgetNotFoundException("No budget exists for the current month");
         }
 
         /// <summary>

--- a/MyMoney.Core/Models/Budget.cs
+++ b/MyMoney.Core/Models/Budget.cs
@@ -19,5 +19,8 @@ namespace MyMoney.Core.Models
 
         [ObservableProperty]
         private ObservableCollection<BudgetExpenseCategory> _budgetExpenseItems = [];
+
+        [ObservableProperty]
+        private ObservableCollection<BudgetSavingsCategory> _budgetSavingsCategories = [];
     }
 }

--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -1,0 +1,24 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyMoney.Core.Models
+{
+    public partial class BudgetSavingsCategory : ObservableObject
+    {
+        [ObservableProperty]
+        private int _id = 0;
+
+        [ObservableProperty]
+        private string _categoryName = string.Empty;
+
+        [ObservableProperty]
+        private Currency _currentBalance = new(0m);
+
+        [ObservableProperty]
+        private Currency _budgetedAmount = new(0m);
+    }
+}

--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -20,5 +20,8 @@ namespace MyMoney.Core.Models
 
         [ObservableProperty]
         private Currency _budgetedAmount = new(0m);
+
+        [ObservableProperty]
+        private Currency _spent = new(0m);
     }
 }

--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace MyMoney.Core.Models
 {
-    public partial class BudgetSavingsCategory : ObservableObject
+    public partial class BudgetSavingsCategory : ObservableObject, ICloneable
     {
         [ObservableProperty]
         private int _id = 0;
@@ -27,5 +27,18 @@ namespace MyMoney.Core.Models
 
         [ObservableProperty]
         private ObservableCollection<Transaction> _transactions = [];
+
+        public object Clone()
+        {
+            return new BudgetSavingsCategory
+            {
+                CategoryName = this.CategoryName,
+                CurrentBalance = new Currency(this.CurrentBalance.Value),
+                Spent = new Currency(0.0m),
+                BudgetedAmount = new(this.BudgetedAmount.Value),
+                Transactions = []
+            };
+        }
+
     }
 }

--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -23,5 +24,8 @@ namespace MyMoney.Core.Models
 
         [ObservableProperty]
         private Currency _spent = new(0m);
+
+        [ObservableProperty]
+        private ObservableCollection<Transaction> _transactions = [];
     }
 }

--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -26,6 +26,9 @@ namespace MyMoney.Core.Models
         private Currency _spent = new(0m);
 
         [ObservableProperty]
+        private string _plannedTransactionHash = string.Empty;
+
+        [ObservableProperty]
         private ObservableCollection<Transaction> _transactions = [];
 
         public object Clone()

--- a/MyMoney.Core/Models/SavingsCategoryReportItem.cs
+++ b/MyMoney.Core/Models/SavingsCategoryReportItem.cs
@@ -1,0 +1,15 @@
+﻿namespace MyMoney.Core.Models
+{
+    public class SavingsCategoryReportItem
+    {
+        public int Id { get; set; }
+
+        public string Category { get; set; } = string.Empty;
+
+        public Currency Saved { get; set; } = new(0m);
+
+        public Currency Spent { get; set; } = new(0m);
+
+        public Currency Balance { get; set; } = new(0m);
+    }
+}

--- a/MyMoney.Core/Models/Transaction.cs
+++ b/MyMoney.Core/Models/Transaction.cs
@@ -4,22 +4,40 @@ using System.ComponentModel;
 
 namespace MyMoney.Core.Models;
 
-public partial class Transaction(DateTime date, string payee, Category category, Currency amount, string memo) : ObservableObject
+public partial class Transaction : ObservableObject
 {
-    [ObservableProperty]
-    private string _payee = payee;
+    public Transaction(DateTime date, string payee, Category category, Currency amount, string memo)
+    {
+        Payee = payee;
+        Category = category;
+        Amount = amount;
+        Memo = memo;
+        Date = date;
+
+        if (TransactionHash != "")
+        {
+            // Generate a hash for this transaction
+            TransactionHash = Guid.NewGuid().ToString();
+        }
+ 
+    }
+
+    public string TransactionHash { get; private set; }
 
     [ObservableProperty]
-    private Category _category = category;
+    private string _payee;
 
     [ObservableProperty]
-    private Currency _amount = amount;
+    private Category _category;
 
     [ObservableProperty]
-    private string _memo = memo;
+    private Currency _amount;
 
     [ObservableProperty]
-    private DateTime _date = date;
+    private string _memo;
+
+    [ObservableProperty]
+    private DateTime _date;
 
     public string DateFormatted
     {

--- a/MyMoney.Core/Models/Transaction.cs
+++ b/MyMoney.Core/Models/Transaction.cs
@@ -37,6 +37,9 @@ public partial class Transaction : ObservableObject
     private string _memo;
 
     [ObservableProperty]
+    private string _transactionDetail;
+
+    [ObservableProperty]
     private DateTime _date;
 
     public string DateFormatted

--- a/MyMoney.Tests/MyMoney.Tests.csproj
+++ b/MyMoney.Tests/MyMoney.Tests.csproj
@@ -23,7 +23,4 @@
   <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ViewModelTests\BudgetViewModel\" />
-  </ItemGroup>
 </Project>

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseGroup.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseGroup.cs
@@ -20,6 +20,7 @@ public class AddExpenseGroupTests
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
     private Mock<INewExpenseGroupDialogService> _mockNewExpenseGroupDialogService;
     private Mock<Core.Database.IDatabaseReader> _mockDatabaseReader;
+    private Mock<ISavingsCategoryDialogService> _savingsCategoryDialogService;
 
     [TestInitialize]
     public void Setup()
@@ -29,6 +30,7 @@ public class AddExpenseGroupTests
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockNewExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _savingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
         _mockDatabaseReader = new Mock<Core.Database.IDatabaseReader>();
         
         _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
@@ -45,7 +47,8 @@ public class AddExpenseGroupTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockNewExpenseGroupDialogService.Object
+            _mockNewExpenseGroupDialogService.Object,
+            _savingsCategoryDialogService.Object
         );
 
         viewModel.CurrentBudget = new Budget 
@@ -80,7 +83,8 @@ public class AddExpenseGroupTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockNewExpenseGroupDialogService.Object
+            _mockNewExpenseGroupDialogService.Object,
+            _savingsCategoryDialogService.Object
         );
 
         // Act
@@ -102,7 +106,8 @@ public class AddExpenseGroupTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockNewExpenseGroupDialogService.Object
+            _mockNewExpenseGroupDialogService.Object,
+            _savingsCategoryDialogService.Object
         );
 
         viewModel.CurrentBudget = new Budget();

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseItem.cs
@@ -21,6 +21,7 @@ public class AddExpenseItemTests
     private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
     private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
     private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
 
     [TestInitialize]
@@ -32,6 +33,7 @@ public class AddExpenseItemTests
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
 
         // Setup database reader to return empty collection
         _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
@@ -43,7 +45,8 @@ public class AddExpenseItemTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockExpenseGroupDialogService.Object
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddIncomeItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddIncomeItem.cs
@@ -20,6 +20,7 @@ public class AddIncomeItemTests
     private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
     private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
     private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
 
     [TestInitialize]
@@ -31,6 +32,7 @@ public class AddIncomeItemTests
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
 
         // Setup database reader to return empty collection
         _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
@@ -42,7 +44,8 @@ public class AddIncomeItemTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockExpenseGroupDialogService.Object
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddSavingsCategory.cs
@@ -1,0 +1,154 @@
+using Moq;
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+using MyMoney.Services.ContentDialogs;
+using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.ViewModels.Pages;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+namespace MyMoney.Tests.ViewModelTests.BudgetViewModel;
+
+[TestClass]
+public class AddSavingsCategoryTests
+{
+    private Mock<IContentDialogService> _mockContentDialogService;
+    private Mock<IDatabaseReader> _mockDatabaseReader;
+    private Mock<IMessageBoxService> _mockMessageBoxService;
+    private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
+    private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
+    private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
+    private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockContentDialogService = new Mock<IContentDialogService>();
+        _mockDatabaseReader = new Mock<IDatabaseReader>();
+        _mockMessageBoxService = new Mock<IMessageBoxService>();
+        _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
+        _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
+        _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
+
+        // Setup database reader to return empty collection
+        _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
+            .Returns(new List<Budget>());
+
+        _viewModel = new(
+            _mockContentDialogService.Object,
+            _mockDatabaseReader.Object,
+            _mockMessageBoxService.Object,
+            _mockNewBudgetDialogService.Object,
+            _mockBudgetCategoryDialogService.Object,
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task AddSavingsCategory_WhenCurrentBudgetIsNull_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = null;
+
+        // Act
+        await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockSavingsCategoryDialogService.Verify(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task AddSavingsCategory_WhenEditingIsDisabled_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        _viewModel.IsEditingEnabled = false;
+
+        // Act
+        await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockSavingsCategoryDialogService.Verify(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task AddSavingsCategory_WhenDialogCancelled_ShouldNotAddCategory()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        var dialogViewModel = new SavingsCategoryDialogViewModel();
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Secondary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(0, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+    }
+
+    [TestMethod]
+    public async Task AddSavingsCategory_WhenDialogConfirmed_ShouldAddNewCategory()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        var dialogViewModel = new SavingsCategoryDialogViewModel
+        {
+            Category = "Test Savings",
+            Planned = new Currency(200m)
+        };
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Primary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.AreEqual("Test Savings", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
+        Assert.AreEqual(200m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].BudgetedAmount.Value);
+    }
+
+    [TestMethod]
+    public async Task AddSavingsCategory_WhenSavingsCategoryAlreadyExists_ShouldShowErrorMessage()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(new BudgetSavingsCategory
+        {
+            CategoryName = "Existing Savings",
+            BudgetedAmount = new Currency(100m)
+        });
+
+        var dialogViewModel = new SavingsCategoryDialogViewModel
+        {
+            Category = "Existing Savings",
+            Planned = new Currency(200m)
+        };
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Primary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockMessageBoxService.Verify(x => x.ShowInfoAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<string>()
+        ), Times.Once);
+        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
@@ -135,6 +135,9 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
                 .Returns(new List<Budget> { currentBudget });
 
+            _mockDatabaseReader.Setup(x => x.GetCollection<Account>("Accounts"))
+                .Returns([]);
+
             var dialogViewModel = new NewBudgetDialogViewModel
             {
                 SelectedDate = DateTime.Now.AddMonths(1).ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture),

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
@@ -4,7 +4,9 @@ using MyMoney.Core.Models;
 using MyMoney.Services.ContentDialogs;
 using MyMoney.ViewModels.ContentDialogs;
 using MyMoney.ViewModels.Pages;
-using System.Collections.ObjectModel;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Wpf.Ui;
 using Wpf.Ui.Controls;
 
@@ -53,9 +55,9 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             // Arrange
             var budgetDate = DateTime.Now.AddMonths(1);
             var budgetTitle = budgetDate.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture);
-            
-            var dialogViewModel = new NewBudgetDialogViewModel 
-            { 
+
+            var dialogViewModel = new NewBudgetDialogViewModel
+            {
                 SelectedDate = budgetTitle,
                 UseLastMonthsBudget = false
             };
@@ -73,6 +75,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
             Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
             Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
         }
 
         [TestMethod]
@@ -113,6 +116,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
+            Assert.AreEqual(1, _viewModel.Budgets.Count); // Only the existing budget
             _mockMessageBoxService.Verify(x => x.ShowInfoAsync(
                 "Budget Already Exists",
                 "Cannot create a budget for the selected month because a budget for this month already exists",
@@ -121,26 +125,52 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
         }
 
         [TestMethod]
+        public async Task CreateNewBudget_WhenDialogResultNotPrimary_DoesNotCreateBudget()
+        {
+            // Arrange
+            _mockNewBudgetDialogService.Setup(x => x.ShowDialogAsync(_mockContentDialogService.Object))
+                .ReturnsAsync(ContentDialogResult.Secondary);
+
+            // Act
+            await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
+
+            // Assert
+            Assert.AreEqual(0, _viewModel.Budgets.Count);
+        }
+
+        [TestMethod]
         public async Task CreateNewBudget_WhenCopyingFromCurrentBudget_CopiesAllItems()
         {
             // Arrange
+            var currentBudgetDate = DateTime.Now;
+            var nextBudgetDate = currentBudgetDate.AddMonths(1);
+            var currentBudgetTitle = currentBudgetDate.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture);
+            var nextBudgetTitle = nextBudgetDate.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture);
+
             var currentBudget = new Budget
             {
-                BudgetTitle = DateTime.Now.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture),
-                BudgetDate = DateTime.Now,
+                BudgetTitle = currentBudgetTitle,
+                BudgetDate = currentBudgetDate,
                 BudgetIncomeItems = { new BudgetItem { Category = "Income", Amount = new Currency(1000) } },
-                BudgetExpenseItems = { new BudgetExpenseCategory { CategoryName = "Expense" } }
+                BudgetExpenseItems = { new BudgetExpenseCategory { CategoryName = "Expense" } },
+                BudgetSavingsCategories = {
+                    new BudgetSavingsCategory {
+                        CategoryName = "Save",
+                        BudgetedAmount = new Currency(200),
+                        CurrentBalance = new Currency(500),
+                        Transactions = { new Transaction(currentBudgetDate, "", new Category { Group = "Savings", Name = "Save" }, new Currency(500), "Initial") }
+                    }
+                }
             };
 
             _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
-                .Returns(new List<Budget> { currentBudget });
-
+                .Returns([currentBudget]);
             _mockDatabaseReader.Setup(x => x.GetCollection<Account>("Accounts"))
                 .Returns([]);
 
             var dialogViewModel = new NewBudgetDialogViewModel
             {
-                SelectedDate = DateTime.Now.AddMonths(1).ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture),
+                SelectedDate = nextBudgetTitle,
                 UseLastMonthsBudget = true
             };
 
@@ -164,24 +194,87 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
 
             // Assert
             Assert.AreEqual(2, _viewModel.Budgets.Count);
-            Assert.AreEqual(1, _viewModel.Budgets[0].BudgetIncomeItems.Count);
-            Assert.AreEqual(1, _viewModel.Budgets[0].BudgetExpenseItems.Count);
-            Assert.AreEqual("Income", _viewModel.Budgets[0].BudgetIncomeItems[0].Category);
-            Assert.AreEqual("Expense", _viewModel.Budgets[0].BudgetExpenseItems[0].CategoryName);
+            var newBudget = _viewModel.Budgets[1];
+            Assert.AreEqual(nextBudgetTitle, newBudget.BudgetTitle);
+            Assert.AreEqual(1, newBudget.BudgetIncomeItems.Count);
+            Assert.AreEqual("Income", newBudget.BudgetIncomeItems[0].Category);
+            Assert.AreEqual(1, newBudget.BudgetExpenseItems.Count);
+            Assert.AreEqual("Expense", newBudget.BudgetExpenseItems[0].CategoryName);
+            Assert.AreEqual(1, newBudget.BudgetSavingsCategories.Count);
+
+            var newSavings = newBudget.BudgetSavingsCategories[0];
+            Assert.AreEqual("Save", newSavings.CategoryName);
+            Assert.AreEqual(currentBudget.BudgetSavingsCategories[0].CurrentBalance + currentBudget.BudgetSavingsCategories[0].BudgetedAmount, newSavings.CurrentBalance);
+            Assert.AreEqual(2, newSavings.Transactions.Count); // Old transactions are deleted during copy
+            Assert.AreEqual(newSavings.BudgetedAmount, newSavings.Transactions[1].Amount);
+            Assert.AreEqual(newSavings.PlannedTransactionHash, newSavings.Transactions[1].TransactionHash);
         }
 
         [TestMethod]
-        public async Task CreateNewBudget_WhenDialogResultNotPrimary_DoesNotCreateBudget()
+        public async Task CreateNewBudget_CopyFromLastMonth_NoBudgetsExist_DoesNotThrowAndCreatesEmptyBudget()
         {
             // Arrange
+            var budgetDate = DateTime.Now.AddMonths(1);
+            var budgetTitle = budgetDate.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture);
+
+            _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
+                .Returns(new List<Budget>());
+
+            var dialogViewModel = new NewBudgetDialogViewModel
+            {
+                SelectedDate = budgetTitle,
+                UseLastMonthsBudget = true
+            };
+
+            _mockNewBudgetDialogService.Setup(x => x.GetViewModel())
+                .Returns(dialogViewModel);
             _mockNewBudgetDialogService.Setup(x => x.ShowDialogAsync(_mockContentDialogService.Object))
-                .ReturnsAsync(ContentDialogResult.Secondary);
+                .ReturnsAsync(ContentDialogResult.Primary);
 
             // Act
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(0, _viewModel.Budgets.Count);
+            Assert.AreEqual(1, _viewModel.Budgets.Count);
+            Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
+        }
+
+        [TestMethod]
+        public async Task CreateNewBudget_CopyFromLastMonth_CurrentBudgetNull_DoesNotThrowAndCreatesEmptyBudget()
+        {
+            // Arrange
+            var budgetDate = DateTime.Now.AddMonths(1);
+            var budgetTitle = budgetDate.ToString("MMMM, yyyy", System.Globalization.CultureInfo.InvariantCulture);
+
+            _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
+                .Returns(new List<Budget>());
+
+            var dialogViewModel = new NewBudgetDialogViewModel
+            {
+                SelectedDate = budgetTitle,
+                UseLastMonthsBudget = true
+            };
+
+            _mockNewBudgetDialogService.Setup(x => x.GetViewModel())
+                .Returns(dialogViewModel);
+            _mockNewBudgetDialogService.Setup(x => x.ShowDialogAsync(_mockContentDialogService.Object))
+                .ReturnsAsync(ContentDialogResult.Primary);
+
+            // Ensure CurrentBudget is null
+            _viewModel.GetType().GetProperty("CurrentBudget")!.SetValue(_viewModel, null);
+
+            // Act
+            await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
+
+            // Assert
+            Assert.AreEqual(1, _viewModel.Budgets.Count);
+            Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
+            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
         }
     }
 }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
@@ -19,6 +19,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
         private Mock<INewBudgetDialogService> _mockNewBudgetDialogService = null!;
         private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService = null!;
         private Mock<INewExpenseGroupDialogService> _mockNewExpenseDialogService = null!;
+        private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService = null!;
         private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel = null!;
 
         [TestInitialize]
@@ -30,6 +31,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
             _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
             _mockNewExpenseDialogService = new Mock<INewExpenseGroupDialogService>();
+            _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
 
             _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
                 .Returns(new List<Budget>());
@@ -40,7 +42,8 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockMessageBoxService.Object,
                 _mockNewBudgetDialogService.Object,
                 _mockBudgetCategoryDialogService.Object,
-                _mockNewExpenseDialogService.Object
+                _mockNewExpenseDialogService.Object,
+                _mockSavingsCategoryDialogService.Object
             );
         }
 
@@ -102,7 +105,8 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockMessageBoxService.Object,
                 _mockNewBudgetDialogService.Object,
                 _mockBudgetCategoryDialogService.Object,
-                _mockNewExpenseDialogService.Object
+                _mockNewExpenseDialogService.Object,
+                _mockSavingsCategoryDialogService.Object
             );
 
             // Act
@@ -148,7 +152,8 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockMessageBoxService.Object,
                 _mockNewBudgetDialogService.Object,
                 _mockBudgetCategoryDialogService.Object,
-                _mockNewExpenseDialogService.Object
+                _mockNewExpenseDialogService.Object,
+                _mockSavingsCategoryDialogService.Object
             );
 
             // Act

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseGroup.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseGroup.cs
@@ -20,6 +20,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
         private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
         private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
         private Mock<INewExpenseGroupDialogService> _mockNewExpenseGroupDialogService;
+        private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
         private ViewModels.Pages.BudgetViewModel _viewModel;
 
         [TestInitialize]
@@ -31,6 +32,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
             _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
             _mockNewExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+            _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
 
             // Setup mock database with a test budget
             var testBudget = new Budget
@@ -48,7 +50,8 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockMessageBoxService.Object,
                 _mockNewBudgetDialogService.Object,
                 _mockBudgetCategoryDialogService.Object,
-                _mockNewExpenseGroupDialogService.Object
+                _mockNewExpenseGroupDialogService.Object,
+                _mockSavingsCategoryDialogService.Object
             );
         }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
@@ -18,6 +18,7 @@ public class DeleteExpenseItemTests
     private Mock<IBudgetCategoryDialogService> _budgetCategoryDialogServiceMock;
     private Mock<Core.Database.IDatabaseReader> _databaseReaderMock;
     private Mock<INewExpenseGroupDialogService> _expenseGroupDialogServiceMock;
+    private Mock<ISavingsCategoryDialogService> _savingsCategoryDialogServiceMock;
     private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
 
     [TestInitialize]
@@ -29,6 +30,7 @@ public class DeleteExpenseItemTests
         _budgetCategoryDialogServiceMock = new Mock<IBudgetCategoryDialogService>();
         _databaseReaderMock = new Mock<Core.Database.IDatabaseReader>();
         _expenseGroupDialogServiceMock = new Mock<INewExpenseGroupDialogService>();
+        _savingsCategoryDialogServiceMock = new Mock<ISavingsCategoryDialogService>();
 
         _databaseReaderMock.Setup(x => x.GetCollection<Budget>("Budgets"))
             .Returns(new List<Budget>());
@@ -39,7 +41,8 @@ public class DeleteExpenseItemTests
             _messageBoxServiceMock.Object,
             _newBudgetDialogServiceMock.Object,
             _budgetCategoryDialogServiceMock.Object,
-            _expenseGroupDialogServiceMock.Object
+            _expenseGroupDialogServiceMock.Object,
+            _savingsCategoryDialogServiceMock.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteIncomeItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteIncomeItem.cs
@@ -19,6 +19,7 @@ public class DeleteIncomeItemTests
     private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
     private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
     private Mock<IDatabaseReader> _mockDatabaseReader;
     private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
     private Budget _testBudget;
@@ -33,6 +34,7 @@ public class DeleteIncomeItemTests
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
         _mockDatabaseReader = new Mock<IDatabaseReader>();
 
         // Setup test budget with income items
@@ -59,7 +61,8 @@ public class DeleteIncomeItemTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockExpenseGroupDialogService.Object
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteSavingsCategory.cs
@@ -1,0 +1,121 @@
+using Moq;
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+using MyMoney.Services.ContentDialogs;
+using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.ViewModels.Pages;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+#pragma warning disable CS8618
+
+namespace MyMoney.Tests.ViewModelTests.BudgetViewModel;
+
+[TestClass]
+public class DeleteSavingsCategoryTests
+{
+    private Mock<IContentDialogService> _mockContentDialogService;
+    private Mock<IDatabaseReader> _mockDatabaseReader;
+    private Mock<IMessageBoxService> _mockMessageBoxService;
+    private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
+    private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
+    private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
+    private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockContentDialogService = new Mock<IContentDialogService>();
+        _mockDatabaseReader = new Mock<IDatabaseReader>();
+        _mockMessageBoxService = new Mock<IMessageBoxService>();
+        _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
+        _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
+        _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
+
+        _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
+            .Returns(new List<Budget>());
+
+        _viewModel = new(
+            _mockContentDialogService.Object,
+            _mockDatabaseReader.Object,
+            _mockMessageBoxService.Object,
+            _mockNewBudgetDialogService.Object,
+            _mockBudgetCategoryDialogService.Object,
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task DeleteSavingsCategory_WhenCurrentBudgetIsNull_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = null;
+
+        // Act
+        await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockMessageBoxService.Verify(x => x.ShowAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteSavingsCategory_WhenEditingIsDisabled_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        _viewModel.IsEditingEnabled = false;
+
+        // Act
+        await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockMessageBoxService.Verify(x => x.ShowAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeleteSavingsCategory_WhenUserCancels_ShouldNotDeleteCategory()
+    {
+        // Arrange
+        var budget = new Budget();
+        budget.BudgetSavingsCategories.Add(new BudgetSavingsCategory { CategoryName = "Test Savings", Id = 1 });
+        _viewModel.CurrentBudget = budget;
+        _viewModel.IsEditingEnabled = true;
+        _viewModel.SavingsCategoriesSelectedIndex = 0;
+        _mockMessageBoxService.Setup(x => x.ShowAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(MessageBoxResult.Secondary);
+
+        // Act
+        await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+    }
+
+    [TestMethod]
+    public async Task DeleteSavingsCategory_WhenUserConfirms_ShouldDeleteCategoryAndReorderIds()
+    {
+        // Arrange
+        var budget = new Budget();
+        budget.BudgetSavingsCategories.Add(new BudgetSavingsCategory { CategoryName = "A", Id = 1 });
+        budget.BudgetSavingsCategories.Add(new BudgetSavingsCategory { CategoryName = "B", Id = 2 });
+        budget.BudgetSavingsCategories.Add(new BudgetSavingsCategory { CategoryName = "C", Id = 3 });
+        _viewModel.CurrentBudget = budget;
+        _viewModel.IsEditingEnabled = true;
+        _viewModel.SavingsCategoriesSelectedIndex = 1; // Delete "B"
+        _mockMessageBoxService.Setup(x => x.ShowAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(MessageBoxResult.Primary);
+
+        // Act
+        await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(2, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.AreEqual("A", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
+        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories[0].Id);
+        Assert.AreEqual("C", _viewModel.CurrentBudget.BudgetSavingsCategories[1].CategoryName);
+        Assert.AreEqual(2, _viewModel.CurrentBudget.BudgetSavingsCategories[1].Id);
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseGroup.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseGroup.cs
@@ -20,6 +20,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
         private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
         private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
         private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+        private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
         private Mock<IDatabaseReader> _mockDatabaseReader;
         private ViewModels.Pages.BudgetViewModel _viewModel;
 
@@ -31,6 +32,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
             _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
             _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+            _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
             _mockDatabaseReader = new Mock<IDatabaseReader>();
 
             _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
@@ -47,7 +49,8 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockMessageBoxService.Object,
                 _mockNewBudgetDialogService.Object,
                 _mockBudgetCategoryDialogService.Object,
-                _mockExpenseGroupDialogService.Object
+                _mockExpenseGroupDialogService.Object,
+                _mockSavingsCategoryDialogService.Object
             );
         }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseItem.cs
@@ -18,6 +18,7 @@ public class EditExpenseItem
     private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
     private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
     private Mock<Core.Database.IDatabaseReader> _mockDatabaseReader;
     private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
 
@@ -29,6 +30,7 @@ public class EditExpenseItem
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
         _mockDatabaseReader = new Mock<Core.Database.IDatabaseReader>();
 
         _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
@@ -40,7 +42,8 @@ public class EditExpenseItem
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockExpenseGroupDialogService.Object
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditIncomeItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditIncomeItem.cs
@@ -18,6 +18,7 @@ public class EditIncomeItemTests
     private Mock<INewBudgetDialogService> _mockNewBudgetDialogService = null!;
     private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService = null!;
     private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService = null!;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService = null!;
     private ViewModels.Pages.BudgetViewModel _viewModel = null!;
 
     [TestInitialize]
@@ -29,6 +30,7 @@ public class EditIncomeItemTests
         _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
         _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
         _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
 
         // Setup mock database with a test budget
         var testBudget = new Budget
@@ -50,7 +52,8 @@ public class EditIncomeItemTests
             _mockMessageBoxService.Object,
             _mockNewBudgetDialogService.Object,
             _mockBudgetCategoryDialogService.Object,
-            _mockExpenseGroupDialogService.Object
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditSavingsCategory.cs
@@ -1,0 +1,224 @@
+using Moq;
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+using MyMoney.Services.ContentDialogs;
+using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.ViewModels.Pages;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+
+namespace MyMoney.Tests.ViewModelTests.BudgetViewModel;
+
+[TestClass]
+public class EditSavingsCategoryTests
+{
+    private Mock<IContentDialogService> _mockContentDialogService;
+    private Mock<IDatabaseReader> _mockDatabaseReader;
+    private Mock<IMessageBoxService> _mockMessageBoxService;
+    private Mock<INewBudgetDialogService> _mockNewBudgetDialogService;
+    private Mock<IBudgetCategoryDialogService> _mockBudgetCategoryDialogService;
+    private Mock<INewExpenseGroupDialogService> _mockExpenseGroupDialogService;
+    private Mock<ISavingsCategoryDialogService> _mockSavingsCategoryDialogService;
+    private MyMoney.ViewModels.Pages.BudgetViewModel _viewModel;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockContentDialogService = new Mock<IContentDialogService>();
+        _mockDatabaseReader = new Mock<IDatabaseReader>();
+        _mockMessageBoxService = new Mock<IMessageBoxService>();
+        _mockNewBudgetDialogService = new Mock<INewBudgetDialogService>();
+        _mockBudgetCategoryDialogService = new Mock<IBudgetCategoryDialogService>();
+        _mockExpenseGroupDialogService = new Mock<INewExpenseGroupDialogService>();
+        _mockSavingsCategoryDialogService = new Mock<ISavingsCategoryDialogService>();
+
+        // Setup database reader to return empty collection
+        _mockDatabaseReader.Setup(x => x.GetCollection<Budget>("Budgets"))
+            .Returns(new List<Budget>());
+
+        _viewModel = new(
+            _mockContentDialogService.Object,
+            _mockDatabaseReader.Object,
+            _mockMessageBoxService.Object,
+            _mockNewBudgetDialogService.Object,
+            _mockBudgetCategoryDialogService.Object,
+            _mockExpenseGroupDialogService.Object,
+            _mockSavingsCategoryDialogService.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenCurrentBudgetIsNull_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = null;
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockSavingsCategoryDialogService.Verify(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenEditingIsDisabled_ShouldReturnWithoutAction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        _viewModel.IsEditingEnabled = false;
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockSavingsCategoryDialogService.Verify(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenDialogCancelled_ShouldNotModifyCategory()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        var originalCategory = new BudgetSavingsCategory
+        {
+            CategoryName = "Test Savings",
+            BudgetedAmount = new Currency(100m),
+            CurrentBalance = new Currency(500m)
+        };
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(originalCategory);
+        _viewModel.SavingsCategoriesSelectedIndex = 0;
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Secondary);
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual("Test Savings", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
+        Assert.AreEqual(100m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].BudgetedAmount.Value);
+        Assert.AreEqual(500m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].CurrentBalance.Value);
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenCategoryNameAlreadyExists_ShouldShowErrorMessage()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(new BudgetSavingsCategory
+        {
+            CategoryName = "Savings 1",
+            BudgetedAmount = new Currency(100m)
+        });
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(new BudgetSavingsCategory
+        {
+            CategoryName = "Savings 2",
+            BudgetedAmount = new Currency(200m)
+        });
+        _viewModel.SavingsCategoriesSelectedIndex = 0;
+
+        var dialogViewModel = new SavingsCategoryDialogViewModel
+        {
+            Category = "Savings 2", // Try to rename to existing name
+            Planned = new Currency(100m)
+        };
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Primary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        _mockMessageBoxService.Verify(x => x.ShowInfoAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>()
+        ), Times.Once);
+        Assert.AreEqual("Savings 1", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenBalanceUpdated_ShouldAddBalanceUpdateTransaction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        var originalCategory = new BudgetSavingsCategory
+        {
+            CategoryName = "Test Savings",
+            BudgetedAmount = new Currency(100m),
+            CurrentBalance = new Currency(500m)
+        };
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(originalCategory);
+        _viewModel.SavingsCategoriesSelectedIndex = 0;
+
+        var dialogViewModel = new SavingsCategoryDialogViewModel
+        {
+            Category = "Test Savings",
+            Planned = new Currency(100m),
+            CurrentBalance = new Currency(600m) // Changed balance
+        };
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Primary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(600m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].CurrentBalance.Value);
+        Assert.IsTrue(_viewModel.CurrentBudget.BudgetSavingsCategories[0].Transactions.Any(t => 
+            t.TransactionDetail == "Updated Balance" && 
+            t.Amount.Value == 100m)); // Should add transaction for 100m difference
+    }
+
+    [TestMethod]
+    public async Task EditSavingsCategory_WhenPlannedAmountUpdated_ShouldUpdatePlannedTransaction()
+    {
+        // Arrange
+        _viewModel.CurrentBudget = new Budget();
+        var originalCategory = new BudgetSavingsCategory
+        {
+            CategoryName = "Test Savings",
+            BudgetedAmount = new Currency(100m),
+            CurrentBalance = new Currency(500m)
+        };
+        
+        // Add initial planned transaction
+        var plannedTransaction = new Transaction(DateTime.Today, "",
+            new Category { Group = "Savings", Name = "Test Savings" },
+            new Currency(100m), "Planned This Month");
+        originalCategory.Transactions.Add(plannedTransaction);
+        originalCategory.PlannedTransactionHash = plannedTransaction.TransactionHash;
+        
+        _viewModel.CurrentBudget.BudgetSavingsCategories.Add(originalCategory);
+        _viewModel.SavingsCategoriesSelectedIndex = 0;
+
+        var dialogViewModel = new SavingsCategoryDialogViewModel
+        {
+            Category = "Test Savings",
+            Planned = new Currency(200m), // Changed planned amount
+            CurrentBalance = new Currency(500m)
+        };
+
+        _mockSavingsCategoryDialogService.Setup(x => x.ShowDialogAsync(It.IsAny<IContentDialogService>(), 
+            It.IsAny<string>())).ReturnsAsync(ContentDialogResult.Primary);
+        _mockSavingsCategoryDialogService.Setup(x => x.GetViewModel()).Returns(dialogViewModel);
+
+        // Act
+        await _viewModel.EditSavingsCategoryCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual(200m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].BudgetedAmount.Value);
+        Assert.AreEqual(600m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].CurrentBalance.Value); // 500 + 100
+        var updatedPlannedTransaction = _viewModel.CurrentBudget.BudgetSavingsCategories[0].Transactions
+            .First(t => t.TransactionHash == originalCategory.PlannedTransactionHash);
+        Assert.AreEqual(200m, updatedPlannedTransaction.Amount.Value);
+    }
+}

--- a/MyMoney/App.xaml.cs
+++ b/MyMoney/App.xaml.cs
@@ -83,6 +83,7 @@ namespace MyMoney
                 services.AddSingleton<INewBudgetDialogService, NewBudgetDialogService>();
                 services.AddSingleton<IBudgetCategoryDialogService, BudgetCategoryDialogService>();
                 services.AddSingleton<INewExpenseGroupDialogService, NewExpenseGroupDialogService>();
+                services.AddSingleton<ISavingsCategoryDialogService,  SavingsCategoryDialogService>();
 
             }).Build();
 

--- a/MyMoney/Services/ContentDialogs/SavingsCategoryDialogService.cs
+++ b/MyMoney/Services/ContentDialogs/SavingsCategoryDialogService.cs
@@ -1,0 +1,48 @@
+﻿using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.Views.ContentDialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Services.ContentDialogs
+{
+    public interface ISavingsCategoryDialogService
+    {
+        public void SetViewModel(SavingsCategoryDialogViewModel viewModel);
+        public SavingsCategoryDialogViewModel GetViewModel();
+        public Task<ContentDialogResult> ShowDialogAsync(IContentDialogService dialogService, string title);
+    }
+    public class SavingsCategoryDialogService : ISavingsCategoryDialogService
+    {
+        private SavingsCategoryDialogViewModel _viewModel = new();
+
+        public SavingsCategoryDialogViewModel GetViewModel()
+        {
+            return _viewModel;
+        }
+
+        public void SetViewModel(SavingsCategoryDialogViewModel viewModel)
+        {
+            _viewModel = viewModel;
+        }
+
+        public async Task<ContentDialogResult> ShowDialogAsync(IContentDialogService dialogService, string title)
+        {
+            var host = dialogService.GetDialogHost();
+            if (host == null)
+                return ContentDialogResult.None;
+
+            SavingsCategoryDialog dialog = new(host, _viewModel)
+            {
+                PrimaryButtonText = "OK",
+                CloseButtonText = "Cancel",
+                Title = title
+            };
+            return await dialogService.ShowAsync(dialog, CancellationToken.None);
+        }
+    }
+}

--- a/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using MyMoney.Core.Models;
+using System.Collections.ObjectModel;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
@@ -12,5 +13,8 @@ namespace MyMoney.ViewModels.ContentDialogs
 
         [ObservableProperty]
         private Currency _currentBalance = new(0m);
+
+        [ObservableProperty]
+        private ObservableCollection<Transaction> _recentTransactions = [];
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
@@ -1,0 +1,16 @@
+﻿using MyMoney.Core.Models;
+
+namespace MyMoney.ViewModels.ContentDialogs
+{
+    public partial class SavingsCategoryDialogViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string _category = string.Empty;
+
+        [ObservableProperty]
+        private Currency _planned = new(0m);
+
+        [ObservableProperty]
+        private Currency _currentBalance = new(0m);
+    }
+}

--- a/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using MyMoney.Core.Models;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
@@ -16,5 +17,33 @@ namespace MyMoney.ViewModels.ContentDialogs
 
         [ObservableProperty]
         private ObservableCollection<Transaction> _recentTransactions = [];
+
+        [ObservableProperty]
+        private Visibility _recentTransactionsVisibility = Visibility.Visible;
+
+        [ObservableProperty]
+        private GridLength _recentTransactionsColumnWidth = new(1, GridUnitType.Star);
+
+        [ObservableProperty]
+        private GridLength _editColumnWidth = new(200, GridUnitType.Pixel);
+
+        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+
+            if (e.PropertyName == nameof(RecentTransactionsVisibility))
+            {
+                if (RecentTransactionsVisibility == Visibility.Collapsed)
+                {
+                    RecentTransactionsColumnWidth = new(0, GridUnitType.Pixel);
+                    EditColumnWidth = new(1, GridUnitType.Star);
+                }
+                else
+                {
+                    RecentTransactionsColumnWidth = new(1, GridUnitType.Star);
+                    EditColumnWidth = new(200, GridUnitType.Pixel);
+                }
+            }
+        }
     }
 }

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -418,8 +418,16 @@ namespace MyMoney.ViewModels.Pages
                 {
                     CategoryName = viewModel.Category,
                     BudgetedAmount = viewModel.Planned,
-                    CurrentBalance = viewModel.CurrentBalance,
+                    CurrentBalance = viewModel.CurrentBalance + viewModel.Planned,
                 };
+
+                // Add a transaction that applies the budgeted amount to the savings category
+                Transaction appliedBudgetedAmount = new(CurrentBudget.BudgetDate, "", 
+                    new Category() { Group = "Savings", Name = category.CategoryName },
+                    category.BudgetedAmount, "Planned This Month");
+                appliedBudgetedAmount.TransactionDetail = "Planned This Month";
+
+                category.Transactions.Add(appliedBudgetedAmount);
 
                 // Add the category to the list of savings categories
                 CurrentBudget.BudgetSavingsCategories.Add(category);
@@ -599,6 +607,7 @@ namespace MyMoney.ViewModels.Pages
                     CategoryName = viewModel.Category,
                     BudgetedAmount = viewModel.Planned,
                     CurrentBalance = viewModel.CurrentBalance,
+                    Transactions = viewModel.RecentTransactions,
                 };
 
                 // assign the selected index of the list with the new item
@@ -794,10 +803,7 @@ namespace MyMoney.ViewModels.Pages
                     foreach (var item in CurrentBudget.BudgetSavingsCategories)
                     {
                         // We have to modify the item before copying it over
-                        var newSavingsCategory = item;
-
-                        // Remove all the transactions
-                        newSavingsCategory.Transactions.Clear();
+                        BudgetSavingsCategory newSavingsCategory = (BudgetSavingsCategory)item.Clone();
 
                         // Add a new transaction that carries the balance forward
                         Transaction balanceCarriedForward = new(newBudget.BudgetDate, "", 
@@ -807,6 +813,16 @@ namespace MyMoney.ViewModels.Pages
                             TransactionDetail = CurrentBudget.BudgetDate.ToString("MMM") + " balance"
                         };
                         newSavingsCategory.Transactions.Add(balanceCarriedForward);
+
+                        // Add a transaction that applies the budgeted amount to the total balance
+                        Transaction appliedBudgetedAmount = new(newBudget.BudgetDate, "",
+                            new Category() { Group = "Savings", Name = item.CategoryName },
+                            item.BudgetedAmount, "Planned This Month");
+                        appliedBudgetedAmount.TransactionDetail = "Planned This Month";
+
+                        newSavingsCategory.Transactions.Add(appliedBudgetedAmount);
+
+                        newSavingsCategory.CurrentBalance += newSavingsCategory.BudgetedAmount;
 
                         newBudget.BudgetSavingsCategories.Add(newSavingsCategory);
                     }

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -910,11 +910,17 @@ namespace MyMoney.ViewModels.Pages
             // get a budget report for the month of the current budget
             var incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(CurrentBudget.BudgetDate, _databaseReader);
             var expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(CurrentBudget.BudgetDate, _databaseReader);
+            var savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(CurrentBudget.BudgetDate, _databaseReader);
 
             // go through the report items and set the equivalent budget items' actual amount
             for (int i = 0; i < incomeItems.Count; i++)
             {
                 CurrentBudget.BudgetIncomeItems[i].Actual = incomeItems[i].Actual;
+            }
+
+            for (int i = 0; i < savingsItems.Count; i++)
+            {
+                CurrentBudget.BudgetSavingsCategories[i].Spent = savingsItems[i].Spent;
             }
 
             foreach (var expenseGroup in CurrentBudget.BudgetExpenseItems)

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -398,7 +398,10 @@ namespace MyMoney.ViewModels.Pages
             if (CurrentBudget == null) return;
             if (!IsEditingEnabled) return;
 
-            var viewModel = new SavingsCategoryDialogViewModel();
+            var viewModel = new SavingsCategoryDialogViewModel()
+            {
+                RecentTransactionsVisibility = Visibility.Collapsed,
+            };
             _savingsCategoryDialogService.SetViewModel(viewModel);
             var result = await _savingsCategoryDialogService.ShowDialogAsync(_contentDialogService, "New Savings Category");
             viewModel = _savingsCategoryDialogService.GetViewModel();

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -175,6 +175,7 @@ namespace MyMoney.ViewModels.Pages
 
         public void OnPageNavigatedTo()
         {
+            LoadBudgetCollection();
             UpdateCharts();
             UpdateBudgetLists();
             UpdateListViewTotals();
@@ -183,6 +184,18 @@ namespace MyMoney.ViewModels.Pages
             if (Budgets.Count > 0)
             {
                 SelectedGroupedBudgetIndex = 0;
+            }
+        }
+
+        private void LoadBudgetCollection()
+        {
+            Budgets.Clear();
+
+            var budgetCollection = _databaseReader.GetCollection<Budget>("Budgets");
+
+            foreach (var budget in budgetCollection.OfType<Budget>())
+            {
+                Budgets.Add(budget);
             }
         }
 

--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -16,6 +16,7 @@ namespace MyMoney.ViewModels.Pages
         public ObservableCollection<AccountDashboardDisplayItem> Accounts { get; set; } = [];
         public ObservableCollection<BudgetReportItem> BudgetReportIncomeItems { get; set; } = [];
         public ObservableCollection<BudgetReportItem> BudgetReportExpenseItems { get; set; } = [];
+        public ObservableCollection<SavingsCategoryReportItem> BudgetReportSavingsItems { get; set; } = [];
 
         [ObservableProperty]
         private double _income;
@@ -96,9 +97,11 @@ namespace MyMoney.ViewModels.Pages
             // clear the current report
             BudgetReportIncomeItems.Clear();
             BudgetReportExpenseItems.Clear();
+            BudgetReportSavingsItems.Clear();
 
             var incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(_databaseReader);
             var expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(_databaseReader);
+            var savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(DateTime.Today, _databaseReader);
 
             foreach (var item in incomeItems)
             {
@@ -108,6 +111,11 @@ namespace MyMoney.ViewModels.Pages
             foreach (var item in expenseItems)
             {
                 BudgetReportExpenseItems.Add(item);
+            }
+
+            foreach (var item in savingsItems)
+            {
+                BudgetReportSavingsItems.Add(item);
             }
 
             // Add an item to the income list showing the total income

--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -172,10 +172,16 @@ namespace MyMoney.ViewModels.Pages
 
         private ISeries[] UpdateChartSeries()
         {
+            var past12MonthsIncome = IncomeExpense12MonthCalculator.GetPast12MonthsIncome();
+            var past12MonthsExpenses = IncomeExpense12MonthCalculator.GetPast12MonthsExpenses();
+
+            var incomeTotal = past12MonthsIncome.Count > 0 ? past12MonthsIncome[^1] : 0.0;
+            var expenseTotal = past12MonthsExpenses.Count > 0 ? past12MonthsExpenses[^1] : 0.0;
+
             var accentColor = ApplicationAccentColorManager.GetColorizationColor();
             ISeries[] s = [new ColumnSeries<double>()
             {
-                Values = [Income, Expenses],
+                Values = [incomeTotal, expenseTotal],
                 Fill = new SolidColorPaint(new SKColor(accentColor.R, accentColor.G, accentColor.B)),
                 Stroke = null,
             }];

--- a/MyMoney/ViewModels/Pages/ReportPages/BudgetReportsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/ReportPages/BudgetReportsViewModel.cs
@@ -202,6 +202,13 @@ namespace MyMoney.ViewModels.Pages.ReportPages
                 expenseTotals.Add(ExpenseItems[j].Category, (double)ExpenseItems[j].Actual.Value);
             }
 
+            for (var k = 0; k < SavingsItems.Count; k++)
+            {
+                if (SavingsItems[k].Saved.Value == 0m) continue;
+
+                expenseTotals.Add(SavingsItems[k].Category, (double)SavingsItems[k].Saved.Value);
+            }
+
             ActualExpenseSeries = new ISeries[expenseTotals.Count];
             var i = 0;
             foreach (var item in expenseTotals)

--- a/MyMoney/ViewModels/Pages/ReportPages/BudgetReportsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/ReportPages/BudgetReportsViewModel.cs
@@ -23,6 +23,9 @@ namespace MyMoney.ViewModels.Pages.ReportPages
         private ObservableCollection<BudgetReportItem> _expenseItems = [];
 
         [ObservableProperty]
+        private ObservableCollection<SavingsCategoryReportItem> _savingsItems = [];
+
+        [ObservableProperty]
         private Currency _reportTotal = new(0m);
 
         [ObservableProperty]
@@ -106,9 +109,11 @@ namespace MyMoney.ViewModels.Pages.ReportPages
             // clear the current report
             IncomeItems.Clear();
             ExpenseItems.Clear();
+            SavingsItems.Clear();
 
             var incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(date, databaseReader);
             var expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(date, databaseReader);
+            var savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(date, databaseReader);
 
             foreach (var item in incomeItems)
             {
@@ -118,6 +123,11 @@ namespace MyMoney.ViewModels.Pages.ReportPages
             foreach (var item in expenseItems)
             {
                 ExpenseItems.Add(item);
+            }
+
+            foreach (var item in savingsItems)
+            {
+                SavingsItems.Add(item);
             }
 
             // Add an item to the income list showing the total income

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -6,36 +6,86 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
       xmlns:helpers="clr-namespace:MyMoney.Helpers" 
-      xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs" 
-      d:DataContext="{d:DesignInstance Type=contentdialogs:SavingsCategoryDialogViewModel}"
+      xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs" xmlns:Controls="clr-namespace:MyMoney.Views.Controls" xmlns:models="clr-namespace:MyMoney.Core.Models;assembly=MyMoney.Core"
+                  d:DataContext="{d:DesignInstance Type=contentdialogs:SavingsCategoryDialogViewModel}"
       mc:Ignorable="d" 
-      d:DesignHeight="450" d:DesignWidth="800"
+      d:DesignHeight="450" d:DesignWidth="600"
       Title="SavingsCategoryDialog"
-      Closing="ContentDialog_Closing">
+      Closing="ContentDialog_Closing"
+      DialogMaxWidth="600">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
+        <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:SavingsCategoryDialog}" />
     </ui:ContentDialog.Resources>
-    <StackPanel>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="200"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
         <ui:TextBlock>Category</ui:TextBlock>
-        <Border BorderThickness="1" BorderBrush="Transparent" x:Name="TxtCategoryBorder" Margin="0,8,0,0">
-             <ui:TextBox x:Name="TxtCategory" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" MinWidth="300" 
+        <Border Grid.Row="1" BorderThickness="1" BorderBrush="Transparent" x:Name="TxtCategoryBorder" Margin="0,8,0,0">
+            <ui:TextBox x:Name="TxtCategory" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}"
                         GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
                         GotMouseCapture="TxtCategory_GotMouseCapture"
-                        LostFocus="TxtCategory_LostFocus"/>           
+                        LostFocus="TxtCategory_LostFocus"/>
         </Border>
 
 
-        <ui:TextBlock Margin="0,12,0,0">Planned for this month</ui:TextBlock>
-        <ui:TextBox x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}, 
+        <ui:TextBlock Grid.Row="2" Margin="0,12,0,0">Planned for this month</ui:TextBlock>
+        <ui:TextBox Grid.Row="3" x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}, 
             UpdateSourceTrigger=PropertyChanged}" Margin="1,8,1,0"
                     GotKeyboardFocus="TxtPlanned_GotKeyboardFocus"
                     GotMouseCapture="TxtPlanned_GotMouseCapture"/>
 
-        <ui:TextBlock Margin="0,12,0,0">Current balance</ui:TextBlock>
-        <ui:TextBox x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}, 
+        <ui:TextBlock Grid.Row="4" Margin="0,12,0,0">Current balance</ui:TextBlock>
+        <ui:TextBox Grid.Row="5" x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}, 
             UpdateSourceTrigger=PropertyChanged}" 
                     Margin="1,8,1,0" GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
                     GotMouseCapture="TxtBalance_GotMouseCapture"/>
-    </StackPanel>
+        <ui:TextBlock Margin="24,0,0,0" Grid.Column="1">Recent activity</ui:TextBlock>
+        <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="5" BorderThickness="1" BorderBrush="#828790" Margin="24,12,0,0"
+                MinWidth="300">
+            <ui:ListView ItemsSource="{Binding RecentTransactions}" Margin="0,0,0,0">
+                <ui:ListView.ItemTemplate>
+                    <DataTemplate DataType="{x:Type models:Transaction}">
+                        <Grid Margin="0,2,0,2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="3*"/>
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <Controls:MonthDayControl Day="{Binding Path=Date.Day}" Month="{Binding Path=MonthAbbreviated}" 
+                                                      HorizontalAlignment="Left" Margin="8,0,0,0" DayFontSize="16"/>
+
+                            <TextBlock Grid.Column="1" Text="{Binding TransactionDetail}" VerticalAlignment="Center"/>
+
+                            <TextBlock Grid.Column="2" FontSize="16" FontWeight="SemiBold" VerticalAlignment="Center"
+                                                  Text="{Binding AmountFormatted}" HorizontalAlignment="Right" Margin="0,0,8,0">
+                                <TextBlock.Style>
+                                    <Style TargetType="TextBlock">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter} }" Value="True">
+                                                <Setter Property="Foreground" Value="{DynamicResource AccentTextFillColorTertiaryBrush}"/>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </TextBlock.Style>
+                            </TextBlock>
+                        </Grid>
+                    </DataTemplate>
+                </ui:ListView.ItemTemplate>
+            </ui:ListView>
+        </Border>
+    </Grid>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -12,7 +12,8 @@
       d:DesignHeight="450" d:DesignWidth="600"
       Title="SavingsCategoryDialog"
       Closing="ContentDialog_Closing"
-      DialogMaxWidth="600">
+      DialogMaxWidth="600"
+      DialogMaxHeight="500">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
         <helpers:StartsWithPlusConverter x:Key="StartsWithPlusConverter"/>
@@ -30,6 +31,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <ui:TextBlock>Category</ui:TextBlock>
@@ -53,7 +55,7 @@
                     Margin="1,8,1,0" GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
                     GotMouseCapture="TxtBalance_GotMouseCapture"/>
         <ui:TextBlock Margin="24,0,0,0" Grid.Column="1">Recent activity</ui:TextBlock>
-        <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="5" BorderThickness="1" BorderBrush="#828790" Margin="24,12,0,0"
+        <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="6" BorderThickness="1" BorderBrush="#828790" Margin="24,12,0,0"
                 MinWidth="300">
             <ui:ListView ItemsSource="{Binding RecentTransactions}" Margin="0,0,0,0">
                 <ui:ListView.ItemTemplate>

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -36,7 +36,7 @@
 
         <ui:TextBlock>Category</ui:TextBlock>
         <Border Grid.Row="1" BorderThickness="1" BorderBrush="Transparent" x:Name="TxtCategoryBorder" Margin="0,8,0,0">
-            <ui:TextBox x:Name="TxtCategory" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}"
+            <ui:TextBox x:Name="TxtCategory" Text="{Binding Category}"
                         GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
                         GotMouseCapture="TxtCategory_GotMouseCapture"
                         LostFocus="TxtCategory_LostFocus"/>
@@ -44,14 +44,13 @@
 
 
         <ui:TextBlock Grid.Row="2" Margin="0,12,0,0">Planned for this month</ui:TextBlock>
-        <ui:TextBox Grid.Row="3" x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}, 
-            UpdateSourceTrigger=PropertyChanged}" Margin="1,8,1,0"
+        <ui:TextBox Grid.Row="3" x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}}" 
+                    Margin="1,8,1,0"
                     GotKeyboardFocus="TxtPlanned_GotKeyboardFocus"
                     GotMouseCapture="TxtPlanned_GotMouseCapture"/>
 
         <ui:TextBlock Grid.Row="4" Margin="0,12,0,0">Current balance</ui:TextBlock>
-        <ui:TextBox Grid.Row="5" x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}, 
-            UpdateSourceTrigger=PropertyChanged}" 
+        <ui:TextBox Grid.Row="5" x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}}" 
                     Margin="1,8,1,0" GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
                     GotMouseCapture="TxtBalance_GotMouseCapture"/>
         <ui:TextBlock Margin="24,0,0,0" Grid.Column="1" Visibility="{Binding RecentTransactionsVisibility}">Recent activity</ui:TextBlock>

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -1,0 +1,28 @@
+﻿<ui:ContentDialog x:Class="MyMoney.Views.ContentDialogs.SavingsCategoryDialog"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
+      xmlns:helpers="clr-namespace:MyMoney.Helpers" 
+      xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs" 
+      d:DataContext="{d:DesignInstance Type=contentdialogs:SavingsCategoryDialogViewModel}"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="SavingsCategoryDialog">
+    <ui:ContentDialog.Resources>
+        <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
+        <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:SavingsCategoryDialog}" />
+    </ui:ContentDialog.Resources>
+    <StackPanel>
+        <ui:TextBlock>Category</ui:TextBlock>
+        <ui:TextBox x:Name="TxtCategory" Text="{Binding Category}" Margin="0,8,0,0" MinWidth="300"/>
+
+        <ui:TextBlock Margin="0,12,0,0">Planned for this month</ui:TextBlock>
+        <ui:TextBox x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}}" Margin="0,8,0,0"/>
+
+        <ui:TextBlock Margin="0,12,0,0">Current balance</ui:TextBlock>
+        <ui:TextBox x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}}" Margin="0,8,0,0"/>
+    </StackPanel>
+</ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -21,8 +21,8 @@
     </ui:ContentDialog.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="200"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="{Binding EditColumnWidth}"/>
+            <ColumnDefinition Width="{Binding RecentTransactionsColumnWidth}"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -54,9 +54,9 @@
             UpdateSourceTrigger=PropertyChanged}" 
                     Margin="1,8,1,0" GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
                     GotMouseCapture="TxtBalance_GotMouseCapture"/>
-        <ui:TextBlock Margin="24,0,0,0" Grid.Column="1">Recent activity</ui:TextBlock>
+        <ui:TextBlock Margin="24,0,0,0" Grid.Column="1" Visibility="{Binding RecentTransactionsVisibility}">Recent activity</ui:TextBlock>
         <Border Grid.Column="1" Grid.Row="1" Grid.RowSpan="6" BorderThickness="1" BorderBrush="#828790" Margin="24,12,0,0"
-                MinWidth="300">
+                MinWidth="300" Visibility="{Binding RecentTransactionsVisibility}">
             <ui:ListView ItemsSource="{Binding RecentTransactions}" Margin="0,0,0,0">
                 <ui:ListView.ItemTemplate>
                     <DataTemplate DataType="{x:Type models:Transaction}">

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -10,19 +10,32 @@
       d:DataContext="{d:DesignInstance Type=contentdialogs:SavingsCategoryDialogViewModel}"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
-      Title="SavingsCategoryDialog">
+      Title="SavingsCategoryDialog"
+      Closing="ContentDialog_Closing">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:SavingsCategoryDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
         <ui:TextBlock>Category</ui:TextBlock>
-        <ui:TextBox x:Name="TxtCategory" Text="{Binding Category}" Margin="0,8,0,0" MinWidth="300"/>
+        <Border BorderThickness="1" BorderBrush="Transparent" x:Name="TxtCategoryBorder" Margin="0,8,0,0">
+             <ui:TextBox x:Name="TxtCategory" Text="{Binding Category, UpdateSourceTrigger=PropertyChanged}" MinWidth="300" 
+                        GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
+                        GotMouseCapture="TxtCategory_GotMouseCapture"
+                        LostFocus="TxtCategory_LostFocus"/>           
+        </Border>
+
 
         <ui:TextBlock Margin="0,12,0,0">Planned for this month</ui:TextBlock>
-        <ui:TextBox x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}}" Margin="0,8,0,0"/>
+        <ui:TextBox x:Name="TxtPlanned" Text="{Binding Planned, Converter={StaticResource CurrencyConverter}, 
+            UpdateSourceTrigger=PropertyChanged}" Margin="1,8,1,0"
+                    GotKeyboardFocus="TxtPlanned_GotKeyboardFocus"
+                    GotMouseCapture="TxtPlanned_GotMouseCapture"/>
 
         <ui:TextBlock Margin="0,12,0,0">Current balance</ui:TextBlock>
-        <ui:TextBox x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}}" Margin="0,8,0,0"/>
+        <ui:TextBox x:Name="TxtBalance" Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}, 
+            UpdateSourceTrigger=PropertyChanged}" 
+                    Margin="1,8,1,0" GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
+                    GotMouseCapture="TxtBalance_GotMouseCapture"/>
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -1,0 +1,31 @@
+﻿using MyMoney.ViewModels.ContentDialogs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace MyMoney.Views.ContentDialogs
+{
+    /// <summary>
+    /// Interaction logic for SavingsCategoryDialog.xaml
+    /// </summary>
+    public partial class SavingsCategoryDialog : Wpf.Ui.Controls.ContentDialog
+    {
+        public SavingsCategoryDialog(ContentPresenter dialogHost, SavingsCategoryDialogViewModel viewModel) : base(dialogHost)
+        {
+            InitializeComponent();
+            DataContext = viewModel;
+            TxtCategory.Focus();
+        }
+    }
+}

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -40,7 +40,7 @@ namespace MyMoney.Views.ContentDialogs
 
         private void TxtBalance_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
-            TxtPlanned.SelectAll();
+            TxtBalance.SelectAll();
         }
 
         private void TxtBalance_GotMouseCapture(object sender, MouseEventArgs e)

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -52,6 +52,9 @@ namespace MyMoney.Views.ContentDialogs
         {
             if (args.Result != ContentDialogResult.Primary) return;
 
+            sender?.MoveFocus(
+                new TraversalRequest(FocusNavigationDirection.Next));
+
             // validate the user data, and if it is invalid, prevent the dialog from closing
 
             // get validation errors for all the required fields

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -1,18 +1,8 @@
 ﻿using MyMoney.ViewModels.ContentDialogs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+using Wpf.Ui.Controls;
 
 namespace MyMoney.Views.ContentDialogs
 {
@@ -26,6 +16,65 @@ namespace MyMoney.Views.ContentDialogs
             InitializeComponent();
             DataContext = viewModel;
             TxtCategory.Focus();
+        }
+
+        private void TxtCategory_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            TxtCategory.SelectAll();
+        }
+
+        private void TxtCategory_GotMouseCapture(object sender, MouseEventArgs e)
+        {
+            TxtCategory.SelectAll();
+        }
+
+        private void TxtPlanned_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            TxtPlanned.SelectAll();
+        }
+
+        private void TxtPlanned_GotMouseCapture(object sender, MouseEventArgs e)
+        {
+            TxtPlanned.SelectAll();
+        }
+
+        private void TxtBalance_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+        {
+            TxtPlanned.SelectAll();
+        }
+
+        private void TxtBalance_GotMouseCapture(object sender, MouseEventArgs e)
+        {
+            TxtBalance.SelectAll();
+        }
+
+        private void ContentDialog_Closing(Wpf.Ui.Controls.ContentDialog sender, Wpf.Ui.Controls.ContentDialogClosingEventArgs args)
+        {
+            if (args.Result != ContentDialogResult.Primary) return;
+
+            // validate the user data, and if it is invalid, prevent the dialog from closing
+
+            // get validation errors for all the required fields
+            var plannedValidationErrors = Validation.GetErrors(TxtPlanned);
+            var balanceValidationErrors = Validation.GetErrors(TxtBalance);
+            var invalidCategory = string.IsNullOrEmpty(TxtCategory.Text);
+
+            // Clear the red border from custom validated controls
+            TxtCategoryBorder.BorderBrush = Brushes.Transparent;
+
+            // validate
+            if (!invalidCategory
+                              && plannedValidationErrors is not { Count: > 0 }
+                              && balanceValidationErrors is not { Count: > 0 }) return;
+            args.Cancel = true;
+
+            if (invalidCategory)
+                TxtCategoryBorder.BorderBrush = Brushes.Red;
+        }
+
+        private void TxtCategory_LostFocus(object sender, RoutedEventArgs e)
+        {
+            TxtCategoryBorder.BorderBrush = string.IsNullOrEmpty(TxtCategory.Text) ? Brushes.Red : Brushes.Transparent;
         }
     }
 }

--- a/MyMoney/Views/Controls/BudgetReportControl.xaml
+++ b/MyMoney/Views/Controls/BudgetReportControl.xaml
@@ -9,21 +9,13 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
     <ui:Card HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch">
-        <Grid>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
+        <StackPanel>
 
             <ui:TextBlock FontTypography="Subtitle" Text="{Binding Title, RelativeSource={RelativeSource AncestorType=UserControl}}" 
                           Margin="0,0,0,24"/>
 
-            <ui:TextBlock Grid.Row="1" FontWeight="SemiBold" Text="Income" Margin="0,0,0,8"/>
-            <ui:ListView Grid.Row="2" ItemsSource="{Binding IncomeItems, RelativeSource={RelativeSource AncestorType=UserControl}}">
+            <ui:TextBlock FontWeight="SemiBold" Text="Income" Margin="0,0,0,8"/>
+            <ui:ListView ItemsSource="{Binding IncomeItems, RelativeSource={RelativeSource AncestorType=UserControl}}">
                 <ListView.Resources>
                     <Style TargetType="{x:Type GridViewColumnHeader}">
                         <Setter Property="HorizontalContentAlignment" Value="Left" />
@@ -47,8 +39,34 @@
                 </ui:ListView.View>
             </ui:ListView>
 
-            <ui:TextBlock FontWeight="SemiBold" Grid.Row="3" Text="Expenses" Margin="0,16,0,8"/>
-            <ui:ListView Grid.Row="4" 
+            <ui:TextBlock FontWeight="SemiBold" Text="Savings" Margin="0,16,0,8"/>
+            <ui:ListView
+                ItemsSource="{Binding SavingsItems, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                <ui:ListView.Resources>
+                    <Style TargetType="{x:Type GridViewColumnHeader}">
+                        <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                    </Style>
+                </ui:ListView.Resources>
+                <ui:ListView.View>
+                    <ui:GridView>
+                        <GridViewColumn Header="Category" 
+                                        Width="{Binding CategoryColumnWidth, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}" 
+                                        DisplayMemberBinding="{Binding Category}" />
+                        <GridViewColumn Header="Saved" 
+                                        Width="{Binding BudgetedColumnWidth, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}" 
+                                        DisplayMemberBinding="{Binding Saved}" />
+                        <GridViewColumn Header="Spent" 
+                                        Width="{Binding ActualColumnWidth, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}" 
+                                        DisplayMemberBinding="{Binding Spent}"/>
+                        <GridViewColumn Header="Balance" 
+                                        Width="{Binding RemainingColumnWidth, Mode=TwoWay, RelativeSource={RelativeSource AncestorType=UserControl}}" 
+                                        DisplayMemberBinding="{Binding Balance}"/>
+                    </ui:GridView>
+                </ui:ListView.View>
+            </ui:ListView>
+
+                <ui:TextBlock FontWeight="SemiBold" Text="Expenses" Margin="0,16,0,8"/>
+            <ui:ListView
                          ItemsSource="{Binding GroupedExpenseItems, RelativeSource={RelativeSource AncestorType=UserControl}}">
                 <ListView.Resources>
                     <Style TargetType="{x:Type GridViewColumnHeader}">
@@ -83,7 +101,7 @@
             </ui:ListView>
 
             <!-- Budget report totals -->
-            <Border Grid.Row="5" Margin="0,16,0,0" BorderThickness="1" BorderBrush="#828790">
+            <Border Margin="0,16,0,0" BorderThickness="1" BorderBrush="#828790">
                 <Grid Margin="12,8,0,8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="{Binding CategoryColumnWidth, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
@@ -96,6 +114,6 @@
                     <ui:TextBlock Grid.Column="3" FontTypography="BodyStrong" Text="{Binding ReportTotal, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
                 </Grid>
             </Border>
-        </Grid>
+        </StackPanel>
     </ui:Card>
 </UserControl>

--- a/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
+++ b/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
@@ -41,6 +41,19 @@ namespace MyMoney.Views.Controls
             set { SetValue(IncomeItemsProperty, value); }
         }
 
+        public static readonly DependencyProperty SavingsItemsProperty =
+            DependencyProperty.Register("SavingsItems", typeof(ObservableCollection<SavingsCategoryReportItem>),
+                typeof(BudgetReportControl), new PropertyMetadata(new ObservableCollection<SavingsCategoryReportItem>()));
+
+        /// <summary>
+        /// The report's savings items
+        /// </summary>
+        public ObservableCollection<SavingsCategoryReportItem> SavingsItems
+        {
+            get { return (ObservableCollection<SavingsCategoryReportItem>)GetValue(SavingsItemsProperty); }
+            set { SetValue(SavingsItemsProperty, value); }
+        }
+
         public static readonly DependencyProperty ExpenseItemsProperty = DependencyProperty.Register("ExpenseItems",
             typeof(ObservableCollection<BudgetReportItem>), typeof(BudgetReportControl),
             new FrameworkPropertyMetadata(new ObservableCollection<BudgetReportItem>(),

--- a/MyMoney/Views/Controls/MonthDayControl.xaml
+++ b/MyMoney/Views/Controls/MonthDayControl.xaml
@@ -14,7 +14,8 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <ui:TextBlock Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Day,
-            RelativeSource={RelativeSource AncestorType=UserControl}}" FontSize="18" FontWeight="SemiBold"/>
+            RelativeSource={RelativeSource AncestorType=UserControl}}" FontSize="{Binding DayFontSize,
+            RelativeSource={RelativeSource AncestorType=UserControl}}" FontWeight="SemiBold"/>
         <ui:TextBlock Grid.Row="1" Grid.Column="0" HorizontalAlignment="Center" Text="{Binding Month,
             RelativeSource={RelativeSource AncestorType=UserControl}}"/>
     </Grid>

--- a/MyMoney/Views/Controls/MonthDayControl.xaml.cs
+++ b/MyMoney/Views/Controls/MonthDayControl.xaml.cs
@@ -52,5 +52,21 @@ namespace MyMoney.Views.Controls
             }
         }
         public static readonly DependencyProperty DayProperty = DependencyProperty.Register("Day", typeof(int), typeof(MonthDayControl), new PropertyMetadata(0));
+
+
+        public int DayFontSize
+        {
+            get
+            {
+                return (int)GetValue(DayFontSizeProperty);
+            }
+            set
+            {
+                SetValue(DayFontSizeProperty, value);
+            }
+        }
+
+        public static readonly DependencyProperty DayFontSizeProperty = DependencyProperty.Register(
+            "DayFontSize", typeof(int), typeof(MonthDayControl), new PropertyMetadata(18));
     }
 }

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -10,7 +10,7 @@
       xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
       xmlns:helpers="clr-namespace:MyMoney.Helpers"
       mc:Ignorable="d" 
-      d:DesignHeight="450" d:DesignWidth="800"
+      d:DesignHeight="600" d:DesignWidth="800"
       Title="Accounts"
       d:DataContext="{d:DesignInstance local:BudgetPage,
                                  IsDesignTimeCreatable=False}"
@@ -83,18 +83,22 @@
                 </StackPanel>
             </ui:Card>
 
-            <StackPanel Orientation="Horizontal" Margin="0,12,0,0">
+            <Grid Margin="0,12,0,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
                 <ui:TextBlock FontTypography="Subtitle" Margin="0,0,0,4">Income</ui:TextBlock>
-                <ui:Button Margin="8,0,0,0" Command="{Binding ViewModel.AddIncomeItemCommand}" IsEnabled="{Binding ViewModel.IsEditingEnabled}">
+                <ui:Button Grid.Column="1" Margin="8,0,0,0" Command="{Binding ViewModel.AddIncomeItemCommand}" IsEnabled="{Binding ViewModel.IsEditingEnabled}">
                     <ui:SymbolIcon Symbol="Add24"/>
                     <ui:Button.ToolTip>
                         <ToolTip Content="Add income item"/>
                     </ui:Button.ToolTip>
                 </ui:Button>
-            </StackPanel>
+            </Grid>
 
 
-            <ui:Card Margin="0,4,0,8">
+            <ui:Card Margin="0,4,0,12">
                 <ui:ListView ItemsSource="{Binding ViewModel.CurrentBudget.BudgetIncomeItems}" 
                              SelectedIndex="{Binding ViewModel.IncomeItemsSelectedIndex}"
                              SizeChanged="ListView_SizeChanged" SelectionMode="Single">
@@ -132,15 +136,71 @@
                 </ui:ListView>
             </ui:Card>
 
-            <StackPanel Orientation="Horizontal">
-                <ui:TextBlock FontTypography="Subtitle" Margin="0,8,0,4">Expenses</ui:TextBlock>
-                <ui:Button Margin="8,0,0,0" IsEnabled="{Binding ViewModel.IsEditingEnabled}" Command="{Binding ViewModel.AddExpenseGroupCommand}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ui:TextBlock FontTypography="Subtitle" Margin="0,12,0,4">Savings</ui:TextBlock>
+                <ui:Button Grid.Column="1" Margin="8,0,0,0" IsEnabled="{Binding ViewModel.IsEditingEnabled}">
+                    <ui:SymbolIcon Symbol="Add24"/>
+                    <ui:Button.ToolTip>
+                        <ToolTip Content="Add savings category"/>
+                    </ui:Button.ToolTip>
+                </ui:Button>
+            </Grid>
+
+            <ui:Card Margin="0,4,0,12">
+                <ui:ListView ItemsSource="{Binding ViewModel.CurrentBudget.BudgetSavingsCategories}" 
+                             SelectedIndex="{Binding ViewModel.IncomeItemsSelectedIndex}"
+                             SizeChanged="ListView_SizeChanged" SelectionMode="Single">
+                    <ui:ListView.Resources>
+                        <DataTemplate x:Key="CategoryItemTemplate">
+                            <ui:TextBlock Text="{Binding CategoryName}" Margin="0,5,0,5"/>
+                        </DataTemplate>
+                        <DataTemplate x:Key="BudgetedItemTemplate">
+                            <ui:TextBlock Text="{Binding BudgetedAmount}" Margin="0,5,0,5"/>
+                        </DataTemplate>
+                        <DataTemplate x:Key="ActualItemTemplate">
+                            <ui:TextBlock Text="{Binding Spent}" Margin="0,5,5,5"/>
+                        </DataTemplate>
+                    </ui:ListView.Resources>
+
+                    <ui:ListView.ContextMenu>
+                        <ContextMenu IsEnabled="{Binding ViewModel.IsEditingEnabled}">
+                            <MenuItem Header="Edit" />
+                            <MenuItem Header="Delete" />
+                        </ContextMenu>
+                    </ui:ListView.ContextMenu>
+
+                    <!--ui:ListView.InputBindings>
+                        <KeyBinding 
+                            Key="Delete" Command="{Binding ViewModel.DeleteIncomeItemCommand}"/>
+                    </ui:ListView.InputBindings-->
+
+                    <ui:ListView.View>
+                        <ui:GridView>
+                            <ui:GridViewColumn Header="Category" CellTemplate="{StaticResource CategoryItemTemplate}"/>
+                            <ui:GridViewColumn Header="Saved" CellTemplate="{StaticResource BudgetedItemTemplate}" Width="125"/>
+                            <ui:GridViewColumn Header="Spent" CellTemplate="{StaticResource ActualItemTemplate}" Width="125"/>
+                        </ui:GridView>
+                    </ui:ListView.View>
+                </ui:ListView>
+            </ui:Card>
+
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <ui:TextBlock Grid.Column="0" FontTypography="Subtitle" Margin="0,12,0,4">Expenses</ui:TextBlock>
+                <ui:Button Grid.Column="1" Margin="8,0,0,0" IsEnabled="{Binding ViewModel.IsEditingEnabled}" Command="{Binding ViewModel.AddExpenseGroupCommand}">
                     <ui:SymbolIcon Symbol="Add24"/>
                     <ui:Button.ToolTip>
                         <ToolTip Content="Add expense group"/>
                     </ui:Button.ToolTip>
                 </ui:Button>
-            </StackPanel>
+            </Grid>
 
             <ItemsControl ItemsSource="{Binding ViewModel.CurrentBudget.BudgetExpenseItems}">
                 <ItemsControl.ItemTemplate>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -142,7 +142,8 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
                 <ui:TextBlock FontTypography="Subtitle" Margin="0,12,0,4">Savings</ui:TextBlock>
-                <ui:Button Grid.Column="1" Margin="8,0,0,0" IsEnabled="{Binding ViewModel.IsEditingEnabled}">
+                <ui:Button Grid.Column="1" Margin="8,0,0,0" IsEnabled="{Binding ViewModel.IsEditingEnabled}" 
+                           Command="{Binding ViewModel.AddSavingsCategoryCommand}">
                     <ui:SymbolIcon Symbol="Add24"/>
                     <ui:Button.ToolTip>
                         <ToolTip Content="Add savings category"/>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -163,7 +163,7 @@
                             <ui:TextBlock Text="{Binding BudgetedAmount}" Margin="0,5,0,5"/>
                         </DataTemplate>
                         <DataTemplate x:Key="ActualItemTemplate">
-                            <ui:TextBlock Text="{Binding Spent}" Margin="0,5,5,5"/>
+                            <ui:TextBlock Text="{Binding CurrentBalance}" Margin="0,5,5,5"/>
                         </DataTemplate>
                     </ui:ListView.Resources>
 
@@ -183,7 +183,7 @@
                         <ui:GridView>
                             <ui:GridViewColumn Header="Category" CellTemplate="{StaticResource CategoryItemTemplate}"/>
                             <ui:GridViewColumn Header="Saved" CellTemplate="{StaticResource BudgetedItemTemplate}" Width="125"/>
-                            <ui:GridViewColumn Header="Spent" CellTemplate="{StaticResource ActualItemTemplate}" Width="125"/>
+                            <ui:GridViewColumn Header="Balance" CellTemplate="{StaticResource ActualItemTemplate}" Width="125"/>
                         </ui:GridView>
                     </ui:ListView.View>
                 </ui:ListView>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -153,7 +153,7 @@
 
             <ui:Card Margin="0,4,0,12">
                 <ui:ListView ItemsSource="{Binding ViewModel.CurrentBudget.BudgetSavingsCategories}" 
-                             SelectedIndex="{Binding ViewModel.IncomeItemsSelectedIndex}"
+                             SelectedIndex="{Binding ViewModel.SavingsCategoriesSelectedIndex}"
                              SizeChanged="ListView_SizeChanged" SelectionMode="Single">
                     <ui:ListView.Resources>
                         <DataTemplate x:Key="CategoryItemTemplate">
@@ -169,15 +169,15 @@
 
                     <ui:ListView.ContextMenu>
                         <ContextMenu IsEnabled="{Binding ViewModel.IsEditingEnabled}">
-                            <MenuItem Header="Edit" />
-                            <MenuItem Header="Delete" />
+                            <MenuItem Header="Edit" Command="{Binding ViewModel.EditSavingsCategoryCommand}"/>
+                            <MenuItem Header="Delete" Command="{Binding ViewModel.DeleteSavingsCategoryCommand}"/>
                         </ContextMenu>
                     </ui:ListView.ContextMenu>
 
-                    <!--ui:ListView.InputBindings>
+                    <ui:ListView.InputBindings>
                         <KeyBinding 
-                            Key="Delete" Command="{Binding ViewModel.DeleteIncomeItemCommand}"/>
-                    </ui:ListView.InputBindings-->
+                            Key="Delete" Command="{Binding ViewModel.DeleteSavingsCategoryCommand}"/>
+                    </ui:ListView.InputBindings>
 
                     <ui:ListView.View>
                         <ui:GridView>

--- a/MyMoney/Views/Pages/DashboardPage.xaml
+++ b/MyMoney/Views/Pages/DashboardPage.xaml
@@ -46,6 +46,7 @@
 
             <Controls:BudgetReportControl   Grid.Column="0" Margin="0,0,8,24"
                                             IncomeItems="{Binding ViewModel.BudgetReportIncomeItems}"
+                                            SavingsItems="{Binding ViewModel.BudgetReportSavingsItems}"
                                             ExpenseItems="{Binding ViewModel.BudgetReportExpenseItems}"
                                             ReportTotal="{Binding ViewModel.DifferenceTotal}"/>
 

--- a/MyMoney/Views/Pages/ReportPages/BudgetReportsPage.xaml
+++ b/MyMoney/Views/Pages/ReportPages/BudgetReportsPage.xaml
@@ -41,7 +41,8 @@
 
         <Controls:BudgetReportControl Grid.Column="1" Grid.ColumnSpan="2"
                 Title="{Binding ViewModel.ReportTitle}" IncomeItems="{Binding ViewModel.IncomeItems}"
-                ExpenseItems="{Binding ViewModel.ExpenseItems}" ReportTotal="{Binding ViewModel.ReportTotal}" Margin="8,0,0,8"/>
+                ExpenseItems="{Binding ViewModel.ExpenseItems}" ReportTotal="{Binding ViewModel.ReportTotal}" Margin="8,0,0,8"
+                SavingsItems="{Binding ViewModel.SavingsItems}"/>
 
         <ui:Card Grid.Column="1" Grid.Row="1" VerticalAlignment="Stretch" Margin="8,8,8,24">
             <lvc:PieChart Height="300" Series="{Binding ViewModel.ActualIncomeSeries}"


### PR DESCRIPTION
Implementation of budget savings categories, which work as sinking funds. These categories allow the user to budget for savings. Each category has a balance that is automatically maintained by the application whenever transactions are added, edited, or deleted. The balance can also be modified manually. The savings categories have their own section in the budget and in budget reports. On budget pie charts, they are displayed as an expense.

Closes #145 