### PR TITLE
Fix the problem with no category being selected when a transaction is being edited

### DIFF
--- a/MyMoney/ViewModels/ContentDialogs/NewTransactionDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/NewTransactionDialogViewModel.cs
@@ -21,6 +21,9 @@ namespace MyMoney.ViewModels.ContentDialogs
         private Category _newTransactionCategory = new();
 
         [ObservableProperty]
+        private int _newTransactionCategorySelectedIndex = -1;
+
+        [ObservableProperty]
         private string _newTransactionMemo = "";
 
         [ObservableProperty]

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -235,7 +235,7 @@ namespace MyMoney.ViewModels.Pages
             var oldTransaction = SelectedAccountTransactions[SelectedTransactionIndex];
             viewModel.NewTransactionDate = oldTransaction.Date;
             viewModel.NewTransactionAmount = new(Math.Abs(oldTransaction.Amount.Value));
-            viewModel.NewTransactionCategory = oldTransaction.Category;
+            viewModel.NewTransactionCategorySelectedIndex = GetCategoryIndex(oldTransaction.Category);
             viewModel.NewTransactionIsExpense = oldTransaction.Amount.Value < 0m;
             viewModel.NewTransactionIsIncome = !viewModel.NewTransactionIsExpense;
             viewModel.NewTransactionMemo = oldTransaction.Memo;
@@ -569,6 +569,17 @@ namespace MyMoney.ViewModels.Pages
                     }
                 }
             }
+        }
+
+        private int GetCategoryIndex(Category category)
+        {
+            for (int i = 0; i < CategoryNames.Count; i++)
+            {
+                if (CategoryNames[i].Group == category.Group && CategoryNames[i].Item.ToString() == category.Name)
+                    return i;
+            }
+
+            return -1;
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -64,6 +64,7 @@
             <controls:GroupedComboBox x:Name="cmbCategory" ItemsSource="{Binding CategoryNames}" 
                                       SelectedItem="{Binding NewTransactionCategory, 
                                         Converter={StaticResource CategoryToGroupedItemConverter}}"
+                                      SelectedIndex="{Binding NewTransactionCategorySelectedIndex}"
                                       SelectionChanged="cmbCategory_SelectionChanged_1"
                                       LostFocus="cmbCategory_LostFocus">
                 

--- a/MyMoney/Views/Controls/GroupedComboBox.xaml.cs
+++ b/MyMoney/Views/Controls/GroupedComboBox.xaml.cs
@@ -130,13 +130,49 @@ namespace MyMoney.Views.Controls
             typeof(ObservableCollection<GroupedComboBoxItem>), typeof(GroupedComboBox), 
             new PropertyMetadata(new ObservableCollection<GroupedComboBoxItem>()));
 
-        
 
-        public class GroupedComboBoxItem
+
+        public class GroupedComboBoxItem : IEquatable<GroupedComboBoxItem>
         {
             public string Group { get; set; } = "";
             public object Item { get; set; } = "";
+
+            public static bool operator ==(GroupedComboBoxItem x, GroupedComboBoxItem y)
+            {
+                return EqualityComparer<GroupedComboBoxItem>.Default.Equals(x, y);
+            }
+
+            public static bool operator !=(GroupedComboBoxItem x, GroupedComboBoxItem y)
+            {
+                return !(x == y);
+            }
+
+            // IEquatable<T> implementation
+            public bool Equals(GroupedComboBoxItem? other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                // Compare Group and Item (using default equality for Item)
+                return string.Equals(Group, other.Group, StringComparison.Ordinal)
+                    && EqualityComparer<object?>.Default.Equals(Item, other.Item);
+            }
+
+            // Override of object.Equals
+            public override bool Equals(object? obj)
+            {
+                if (obj is null) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
+                return Equals((GroupedComboBoxItem)obj);
+            }
+
+            // Override of object.GetHashCode
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(Group, Item);
+            }
         }
+
 
         private void dropdownButton_Click(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
Introduces NewTransactionCategorySelectedIndex to NewTransactionDialogViewModel and binds it to the GroupedComboBox's SelectedIndex for improved category selection synchronization. Adds logic in AccountsViewModel to set the selected category index when editing transactions, and implements equality for GroupedComboBoxItem to support comparison.

This makes so the index of the selected category is passed to the transaction dialog, instead of the actual category itself. Fixes #187 