### PR TITLE
Move focus before closing dialogs

### DIFF
--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
@@ -10,7 +10,8 @@
       d:DataContext="{d:DesignInstance Type=contentdialogs:BudgetCategoryDialogViewModel}"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
-      Title="New Category">
+      Title="New Category"
+      Closing="ContentDialog_Closing">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:BudgetCategoryDialog}" />

--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
@@ -46,5 +46,12 @@ namespace MyMoney.Views.ContentDialogs
         {
             TxtCategory.SelectAll();
         }
+
+        private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        {
+            TxtCategory.Focus();
+            TxtCategory.MoveFocus(
+                new TraversalRequest(FocusNavigationDirection.Next));
+        }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
@@ -10,7 +10,8 @@
       d:DataContext="{d:DesignInstance Type=contentdialogs:NewAccountDialogViewModel}"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
-      Title="New Account">
+      Title="New Account"
+      Closing="ContentDialog_Closing">
     <ui:ContentDialog.Resources>
         <helpers:CurrencyConverter x:Key="CurrencyConverter"/>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewAccountDialog}" />

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MyMoney.ViewModels.ContentDialogs;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Wpf.Ui.Controls;
 
 namespace MyMoney.Views.ContentDialogs
@@ -46,6 +47,13 @@ namespace MyMoney.Views.ContentDialogs
         private void txtStartingBalance_GotMouseCapture(object sender, System.Windows.Input.MouseEventArgs e)
         {
             txtStartingBalance.SelectAll();
+        }
+
+        private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        {
+            TxtAccountName.Focus();
+            TxtAccountName.MoveFocus(
+                new TraversalRequest(FocusNavigationDirection.Next));
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -88,6 +88,9 @@ namespace MyMoney.Views.ContentDialogs
         {
             if (args.Result != ContentDialogResult.Primary) return;
 
+            txtPayee.Focus();
+            txtPayee.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+
             // validate the user data, and if it is invalid, prevent the dialog from closing
 
             // get validation errors for all the required fields

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -52,8 +52,10 @@ namespace MyMoney.Views.ContentDialogs
         {
             if (args.Result != ContentDialogResult.Primary) return;
 
-            sender?.MoveFocus(
+            TxtCategory.Focus();
+            TxtCategory.MoveFocus(
                 new TraversalRequest(FocusNavigationDirection.Next));
+            
 
             // validate the user data, and if it is invalid, prevent the dialog from closing
 

--- a/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using MyMoney.ViewModels.ContentDialogs;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using Wpf.Ui.Controls;
 
@@ -39,6 +40,9 @@ namespace MyMoney.Views.ContentDialogs
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             if (args.Result != ContentDialogResult.Primary) return;
+
+            txtAmount.Focus();
+            txtAmount.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
             // validate the user data, and if it is invalid, prevent the dialog from closing
 


### PR DESCRIPTION
Added logic to set focus and move to the next control when closing various content dialogs (BudgetCategoryDialog, NewAccountDialog, NewTransactionDialog, SavingsCategoryDialog, TransferDialog). This ensures that all property changed events have fired and all sources are updated before the  dialog closes.

Fixes #190 