### PR TITLE
Implement drag and drop on budget page

### DIFF
--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -59,6 +59,11 @@
         "resolved": "8.4.0",
         "contentHash": "tqVU8yc/ADO9oiTRyTnwhFN68hCwvkliMierptWOudIAvWY1mWCh5VFh+guwHJmpMwfg0J0rY+yyd5Oy7ty9Uw=="
       },
+      "gong-wpf-dragdrop": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "nDj86v1XHhgmQR8PPo/uDDp/xdLDxcqZdvIwSxWAHQPiRX/GBXK13FYY0C2xQow9RSl6j5FKLk8xoYrdb52vqg=="
+      },
       "HarfBuzzSharp": {
         "type": "Transitive",
         "resolved": "8.3.0.1",
@@ -585,7 +590,8 @@
           "LiveChartsCore.SkiaSharpView.WPF": "[2.0.0-rc5.4, )",
           "Microsoft.Extensions.Hosting": "[9.0.6, )",
           "MyMoney.Core": "[1.0.0, )",
-          "WPF-UI": "[4.0.3, )"
+          "WPF-UI": "[4.0.3, )",
+          "gong-wpf-dragdrop": "[4.0.0, )"
         }
       },
       "mymoney.core": {

--- a/MyMoney/Helpers/DropHandlers/BudgetExpenseGroupReorderHandler.cs
+++ b/MyMoney/Helpers/DropHandlers/BudgetExpenseGroupReorderHandler.cs
@@ -1,0 +1,47 @@
+﻿using GongSolutions.Wpf.DragDrop;
+using MyMoney.Core.Models;
+using MyMoney.ViewModels.Pages;
+
+namespace MyMoney.Helpers.DropHandlers
+{
+    public class BudgetExpenseGroupReorderHandler(BudgetViewModel viewModel) : IDropTarget
+    {
+        private readonly BudgetViewModel _viewModel = viewModel;
+
+        public void DragOver(IDropInfo dropInfo)
+        {
+            // Only allow moves within the same collection
+            if (ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+            {
+                dropInfo.Effects = DragDropEffects.Move;
+                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            }
+            else
+            {
+                dropInfo.Effects = DragDropEffects.None;
+            }
+        }
+
+        public void Drop(IDropInfo dropInfo)
+        {
+            if (!ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+                return;
+
+            if (dropInfo.DragInfo.SourceCollection is not IList<BudgetExpenseCategory> sourceList ||
+                dropInfo.TargetCollection is not IList<BudgetExpenseCategory> targetList ||
+                dropInfo.Data is not BudgetExpenseCategory item)
+                return;
+
+            int oldIndex = sourceList.IndexOf(item);
+            int newIndex = dropInfo.InsertIndex;
+
+            // If dragging downward in the same list, the removal shifts the target index down by one
+            if (oldIndex < newIndex) newIndex--;
+
+            sourceList.RemoveAt(oldIndex);
+            targetList.Insert(newIndex, item);
+
+            _viewModel.WriteToDatabase();
+        }
+    }
+}

--- a/MyMoney/Helpers/DropHandlers/BudgetExpenseItemMoveAndReorderHandler.cs
+++ b/MyMoney/Helpers/DropHandlers/BudgetExpenseItemMoveAndReorderHandler.cs
@@ -1,0 +1,59 @@
+﻿using GongSolutions.Wpf.DragDrop;
+using MyMoney.Core.Models;
+using MyMoney.ViewModels.Pages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyMoney.Helpers.DropHandlers
+{
+    public class BudgetExpenseItemMoveAndReorderHandler(BudgetViewModel viewModel) : IDropTarget
+    {
+        private readonly BudgetViewModel _viewModel = viewModel;
+
+        public void DragOver(IDropInfo dropInfo)
+        {
+            if (dropInfo.DragInfo.SourceCollection is IList<BudgetItem> &&
+                dropInfo.TargetCollection is IList<BudgetItem>
+                && !ReferenceEquals(dropInfo.DragInfo.SourceCollection, _viewModel.CurrentBudget?.BudgetIncomeItems))
+            {
+                dropInfo.Effects = DragDropEffects.Move;
+                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            }
+            else
+            {
+                dropInfo.Effects = DragDropEffects.None;
+            }
+        }
+
+        public void Drop(IDropInfo dropInfo)
+        {
+            if (dropInfo.DragInfo.SourceCollection is not IList<BudgetItem> sourceList||
+                dropInfo.TargetCollection is not IList<BudgetItem> targetList||
+                dropInfo.Data is not BudgetItem item ||
+                ReferenceEquals(dropInfo.DragInfo.SourceCollection, _viewModel.CurrentBudget?.BudgetIncomeItems))
+                return;
+
+            if (ReferenceEquals(sourceList, targetList)) // Reordering within the same collection
+            {
+                int oldIndex = sourceList.IndexOf(item);
+                int newIndex = dropInfo.InsertIndex;
+
+                // If dragging downward in the same list, the removal shifts the target index down by one
+                if (oldIndex < newIndex) newIndex--;
+
+                sourceList.RemoveAt(oldIndex);
+                targetList.Insert(newIndex, item);
+            }
+            else // Moving to a different collection
+            {
+                sourceList.Remove(item);
+                targetList.Insert(dropInfo.InsertIndex, item);
+            }
+
+            _viewModel.WriteToDatabase();
+        }
+    }
+}

--- a/MyMoney/Helpers/DropHandlers/BudgetIncomeItemReorderHandler.cs
+++ b/MyMoney/Helpers/DropHandlers/BudgetIncomeItemReorderHandler.cs
@@ -1,0 +1,46 @@
+﻿using GongSolutions.Wpf.DragDrop;
+using MyMoney.Core.Models;
+using MyMoney.ViewModels.Pages;
+
+namespace MyMoney.Helpers.DropHandlers
+{
+    public class BudgetIncomeItemReorderHandler(BudgetViewModel viewModel) : IDropTarget
+    {
+        private readonly BudgetViewModel _viewModel = viewModel;
+        public void DragOver(IDropInfo dropInfo)
+        {
+            // Only allow moves within the same collection
+            if (ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+            {
+                dropInfo.Effects = DragDropEffects.Move;
+                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            }
+            else
+            {
+                dropInfo.Effects = DragDropEffects.None;
+            }
+        }
+
+        public void Drop(IDropInfo dropInfo)
+        {
+            if (!ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+                return;
+
+            if (dropInfo.DragInfo.SourceCollection is not IList<BudgetItem> sourceList ||
+                dropInfo.TargetCollection is not IList<BudgetItem> targetList ||
+                dropInfo.Data is not BudgetItem item)
+                return;
+
+            int oldIndex = sourceList.IndexOf(item);
+            int newIndex = dropInfo.InsertIndex;
+
+            // If dragging downward in the same list, the removal shifts the target index down by one
+            if (oldIndex < newIndex) newIndex--;
+
+            sourceList.RemoveAt(oldIndex);
+            targetList.Insert(newIndex, item);
+
+            _viewModel.WriteToDatabase();
+        }
+    }
+}

--- a/MyMoney/Helpers/DropHandlers/BudgetSavingsCategoryReorderHandler.cs
+++ b/MyMoney/Helpers/DropHandlers/BudgetSavingsCategoryReorderHandler.cs
@@ -1,0 +1,47 @@
+﻿using GongSolutions.Wpf.DragDrop;
+using MyMoney.Core.Models;
+using MyMoney.ViewModels.Pages;
+
+namespace MyMoney.Helpers.DropHandlers
+{
+    public class BudgetSavingsCategoryReorderHandler(BudgetViewModel viewModel) : IDropTarget
+    {
+        private readonly BudgetViewModel _viewModel = viewModel;
+
+        public void DragOver(IDropInfo dropInfo)
+        {
+            // Only allow moves within the same collection
+            if (ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+            {
+                dropInfo.Effects = DragDropEffects.Move;
+                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            }
+            else
+            {
+                dropInfo.Effects = DragDropEffects.None;
+            }
+        }
+
+        public void Drop(IDropInfo dropInfo)
+        {
+            if (!ReferenceEquals(dropInfo.DragInfo.SourceCollection, dropInfo.TargetCollection))
+                return;
+
+            if (dropInfo.DragInfo.SourceCollection is not IList<BudgetSavingsCategory> sourceList ||
+                dropInfo.TargetCollection is not IList<BudgetSavingsCategory> targetList ||
+                dropInfo.Data is not BudgetSavingsCategory item)
+                return;
+
+            int oldIndex = sourceList.IndexOf(item);
+            int newIndex = dropInfo.InsertIndex;
+
+            // If dragging downward in the same list, the removal shifts the target index down by one
+            if (oldIndex < newIndex) newIndex--;
+
+            sourceList.RemoveAt(oldIndex);
+            targetList.Insert(newIndex, item);
+
+            _viewModel.WriteToDatabase();
+        }
+    }
+}

--- a/MyMoney/MyMoney.csproj
+++ b/MyMoney/MyMoney.csproj
@@ -16,6 +16,7 @@
     <Content Include="MyMoney-icon.ico" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
     <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0-rc5.4" />
     <PackageReference Include="WPF-UI" Version="4.0.3" />

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -90,6 +90,7 @@ namespace MyMoney.ViewModels.Pages
         // Drop handlers for drag/drop operations
         public BudgetExpenseGroupReorderHandler ExpenseGroupsReorderHandler { get; private set; }
         public BudgetSavingsCategoryReorderHandler SavingsCategoryReorderHandler { get; private set; }
+        public BudgetIncomeItemReorderHandler IncomeItemsReorderHandler { get; private set; }
 
         public class GroupedBudget
         {
@@ -151,6 +152,7 @@ namespace MyMoney.ViewModels.Pages
             // Set up drop handlers
             ExpenseGroupsReorderHandler = new(this);
             SavingsCategoryReorderHandler = new(this);
+            IncomeItemsReorderHandler = new(this);
 
             var budgetCollection = _databaseReader.GetCollection<Budget>("Budgets");
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -89,6 +89,7 @@ namespace MyMoney.ViewModels.Pages
 
         // Drop handlers for drag/drop operations
         public BudgetExpenseGroupReorderHandler ExpenseGroupsReorderHandler { get; private set; }
+        public BudgetSavingsCategoryReorderHandler SavingsCategoryReorderHandler { get; private set; }
 
         public class GroupedBudget
         {
@@ -149,6 +150,7 @@ namespace MyMoney.ViewModels.Pages
 
             // Set up drop handlers
             ExpenseGroupsReorderHandler = new(this);
+            SavingsCategoryReorderHandler = new(this);
 
             var budgetCollection = _databaseReader.GetCollection<Budget>("Budgets");
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -91,6 +91,7 @@ namespace MyMoney.ViewModels.Pages
         public BudgetExpenseGroupReorderHandler ExpenseGroupsReorderHandler { get; private set; }
         public BudgetSavingsCategoryReorderHandler SavingsCategoryReorderHandler { get; private set; }
         public BudgetIncomeItemReorderHandler IncomeItemsReorderHandler { get; private set; }
+        public BudgetExpenseItemMoveAndReorderHandler ExpenseItemsMoveAndReorderHandler { get; private set; }
 
         public class GroupedBudget
         {
@@ -153,6 +154,7 @@ namespace MyMoney.ViewModels.Pages
             ExpenseGroupsReorderHandler = new(this);
             SavingsCategoryReorderHandler = new(this);
             IncomeItemsReorderHandler = new(this);
+            ExpenseItemsMoveAndReorderHandler = new(this);
 
             var budgetCollection = _databaseReader.GetCollection<Budget>("Budgets");
 

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -155,7 +155,11 @@
             <ui:Card Margin="0,4,0,12">
                 <ui:ListView ItemsSource="{Binding ViewModel.CurrentBudget.BudgetSavingsCategories}" 
                              SelectedIndex="{Binding ViewModel.SavingsCategoriesSelectedIndex}"
-                             SizeChanged="ListView_SizeChanged" SelectionMode="Single">
+                             SizeChanged="ListView_SizeChanged" SelectionMode="Single"
+                             dd:DragDrop.IsDragSource="True"
+                             dd:DragDrop.IsDropTarget="True"
+                             dd:DragDrop.DropHandler="{Binding ViewModel.SavingsCategoryReorderHandler}"
+                             dd:DragDrop.DragHandler="{Binding ViewModel.SavingsCategoryReorderHandler}">
                     <ui:ListView.Resources>
                         <DataTemplate x:Key="CategoryItemTemplate">
                             <ui:TextBlock Text="{Binding CategoryName}" Margin="0,5,0,5"/>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -250,7 +250,13 @@
                             <StackPanel>
                                 <ui:ListView ItemsSource="{Binding SubItems}" SelectedIndex="{Binding SelectedSubItemIndex}"
                                              Tag="{Binding DataContext.ViewModel, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
-                                             SelectionMode="Single" MinHeight="50" Margin="0,0,0,8" SizeChanged="ListView_SizeChanged">
+                                             SelectionMode="Single" MinHeight="50" Margin="0,0,0,8" SizeChanged="ListView_SizeChanged"
+                                             dd:DragDrop.IsDragSource="True"
+                                             dd:DragDrop.IsDropTarget="True"
+                                             dd:DragDrop.DropHandler="{Binding DataContext.ViewModel.ExpenseItemsMoveAndReorderHandler,
+                                                                        RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+                                             dd:DragDrop.DragHandler="{Binding DataContext.ViewModel.ExpenseItemsMoveAndReorderHandler,
+                                                                        RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}">
                                     <ui:ListView.Resources>
                                         <DataTemplate x:Key="CategoryItemTemplate">
                                             <ui:TextBlock Text="{Binding Category}" Margin="0,5,0,5"/>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -102,7 +102,11 @@
             <ui:Card Margin="0,4,0,12">
                 <ui:ListView ItemsSource="{Binding ViewModel.CurrentBudget.BudgetIncomeItems}" 
                              SelectedIndex="{Binding ViewModel.IncomeItemsSelectedIndex}"
-                             SizeChanged="ListView_SizeChanged" SelectionMode="Single">
+                             SizeChanged="ListView_SizeChanged" SelectionMode="Single"
+                             dd:DragDrop.IsDragSource="True"
+                             dd:DragDrop.IsDropTarget="True"
+                             dd:DragDrop.DropHandler="{Binding ViewModel.IncomeItemsReorderHandler}"
+                             dd:DragDrop.DragHandler="{Binding ViewModel.IncomeItemsReorderHandler}">
                     <ui:ListView.Resources>
                         <DataTemplate x:Key="CategoryItemTemplate">
                             <ui:TextBlock Text="{Binding Category}" Margin="0,5,0,5"/>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -207,8 +207,8 @@
             <ItemsControl ItemsSource="{Binding ViewModel.CurrentBudget.BudgetExpenseItems}"
                           dd:DragDrop.IsDragSource="True"
                           dd:DragDrop.IsDropTarget="True"
-                          dd:DragDrop.DropHandler="{Binding ViewModel}"
-                          dd:DragDrop.DragHandler="{Binding ViewModel}">
+                          dd:DragDrop.DropHandler="{Binding ViewModel.ExpenseGroupsReorderHandler}"
+                          dd:DragDrop.DragHandler="{Binding ViewModel.ExpenseGroupsReorderHandler}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <ui:CardExpander Margin="0,8,0,8" IsExpanded="True">

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -9,6 +9,7 @@
       xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
       xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.WPF;assembly=LiveChartsCore.SkiaSharpView.WPF"
       xmlns:helpers="clr-namespace:MyMoney.Helpers"
+      xmlns:dd="urn:gong-wpf-dragdrop"
       mc:Ignorable="d" 
       d:DesignHeight="600" d:DesignWidth="800"
       Title="Accounts"
@@ -203,7 +204,11 @@
                 </ui:Button>
             </Grid>
 
-            <ItemsControl ItemsSource="{Binding ViewModel.CurrentBudget.BudgetExpenseItems}">
+            <ItemsControl ItemsSource="{Binding ViewModel.CurrentBudget.BudgetExpenseItems}"
+                          dd:DragDrop.IsDragSource="True"
+                          dd:DragDrop.IsDropTarget="True"
+                          dd:DragDrop.DropHandler="{Binding ViewModel}"
+                          dd:DragDrop.DragHandler="{Binding ViewModel}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
                         <ui:CardExpander Margin="0,8,0,8" IsExpanded="True">

--- a/MyMoney/packages.lock.json
+++ b/MyMoney/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "8.4.0",
         "contentHash": "tqVU8yc/ADO9oiTRyTnwhFN68hCwvkliMierptWOudIAvWY1mWCh5VFh+guwHJmpMwfg0J0rY+yyd5Oy7ty9Uw=="
       },
+      "gong-wpf-dragdrop": {
+        "type": "Direct",
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "nDj86v1XHhgmQR8PPo/uDDp/xdLDxcqZdvIwSxWAHQPiRX/GBXK13FYY0C2xQow9RSl6j5FKLk8xoYrdb52vqg=="
+      },
       "LiteDB": {
         "type": "Direct",
         "requested": "[5.0.21, )",


### PR DESCRIPTION
Implement dragging and dropping from various lists on the budget page.

- Reordering Income items
- Reordering Savings categories
- Reordering Expense groups
- Reordering Expense items within groups
- Moving Expense items between groups

Closes #173 