### PR TITLE
Update delete group confirmation message

### DIFF
--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -754,7 +754,7 @@ namespace MyMoney.ViewModels.Pages
 
             // as user if they really want to delete the group
             var result = await _messageBoxService.ShowAsync("Delete Group?",
-                "Are you sure you want to delete the selected category?",
+                "Are you sure you want to delete this group?",
                 "Yes",
                 "No");
 


### PR DESCRIPTION
Changed the confirmation dialog text from 'Are you sure you want to delete the selected category?' to 'Are you sure you want to delete this group?' for clarity when deleting a group.