### PR TITLE
Add category hash and balance tracking to savings categories

### DIFF
--- a/MyMoney.Core/Models/BudgetSavingsCategory.cs
+++ b/MyMoney.Core/Models/BudgetSavingsCategory.cs
@@ -29,7 +29,21 @@ namespace MyMoney.Core.Models
         private string _plannedTransactionHash = string.Empty;
 
         [ObservableProperty]
+        private string _balanceTransactionHash = string.Empty;
+
+        [ObservableProperty]
         private ObservableCollection<Transaction> _transactions = [];
+
+        public string CategoryHash { get; private set; } = "";
+
+        public BudgetSavingsCategory()
+        {
+            if (CategoryHash == "")
+            {
+                // Generate a hash for this category
+                CategoryHash = Guid.NewGuid().ToString();
+            }
+        }
 
         public object Clone()
         {
@@ -39,7 +53,8 @@ namespace MyMoney.Core.Models
                 CurrentBalance = new Currency(this.CurrentBalance.Value),
                 Spent = new Currency(0.0m),
                 BudgetedAmount = new(this.BudgetedAmount.Value),
-                Transactions = []
+                Transactions = [],
+                CategoryHash = this.CategoryHash
             };
         }
 

--- a/MyMoney.Core/Models/Transaction.cs
+++ b/MyMoney.Core/Models/Transaction.cs
@@ -14,7 +14,7 @@ public partial class Transaction : ObservableObject
         Memo = memo;
         Date = date;
 
-        if (TransactionHash != "")
+        if (TransactionHash == "")
         {
             // Generate a hash for this transaction
             TransactionHash = Guid.NewGuid().ToString();
@@ -22,7 +22,7 @@ public partial class Transaction : ObservableObject
  
     }
 
-    public string TransactionHash { get; private set; }
+    public string TransactionHash { get; private set; } = "";
 
     [ObservableProperty]
     private string _payee;


### PR DESCRIPTION
Introduces a unique CategoryHash and BalanceTransactionHash to BudgetSavingsCategory for better identification and tracking. Ensures hashes are generated if missing, fixes Transaction hash initialization logic, and adds logic to update future savings categories when balances are edited. Also updates related transaction and balance handling in BudgetViewModel.

Fixes #202 