### PR TITLE
Persist IsExpanded property for budget groups

### DIFF
--- a/MyMoney.Core/Models/BudgetExpenseCategory.cs
+++ b/MyMoney.Core/Models/BudgetExpenseCategory.cs
@@ -22,6 +22,9 @@ namespace MyMoney.Core.Models
         [ObservableProperty]
         private int _selectedSubItemIndex = 1;
 
+        [ObservableProperty]
+        private bool _isExpanded;
+
         public Currency CategoryTotal
         {
             get

--- a/MyMoney/Helpers/CardExpanderStateHelper.cs
+++ b/MyMoney/Helpers/CardExpanderStateHelper.cs
@@ -1,0 +1,49 @@
+﻿using Wpf.Ui.Controls;
+
+namespace MyMoney.Helpers
+{
+    public static class CardExpanderStateHelper
+    {
+        public static readonly DependencyProperty SyncedIsExpandedProperty =
+            DependencyProperty.RegisterAttached(
+                "SyncedIsExpanded",
+                typeof(bool),
+                typeof(CardExpanderStateHelper),
+                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSyncedIsExpandedChanged));
+
+        public static void SetSyncedIsExpanded(DependencyObject element, bool value)
+            => element.SetValue(SyncedIsExpandedProperty, value);
+
+        public static bool GetSyncedIsExpanded(DependencyObject element)
+            => (bool)element.GetValue(SyncedIsExpandedProperty);
+
+        private static void OnSyncedIsExpandedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is CardExpander expander)
+            {
+                // Prevent recursive updates
+                if (expander.IsExpanded != (bool)e.NewValue)
+                    expander.IsExpanded = (bool)e.NewValue;
+
+                expander.Expanded -= Expander_Expanded;
+                expander.Collapsed -= Expander_Collapsed;
+
+                expander.Expanded += Expander_Expanded;
+                expander.Collapsed += Expander_Collapsed;
+            }
+        }
+
+        private static void Expander_Expanded(object sender, RoutedEventArgs e)
+        {
+            if (sender is CardExpander expander)
+                SetSyncedIsExpanded(expander, true);
+        }
+
+        private static void Expander_Collapsed(object sender, RoutedEventArgs e)
+        {
+            if (sender is CardExpander expander)
+                SetSyncedIsExpanded(expander, false);
+        }
+    }
+
+}

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -226,7 +226,8 @@
                           dd:DragDrop.DragHandler="{Binding ViewModel.ExpenseGroupsReorderHandler}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <ui:CardExpander Margin="0,8,0,8" IsExpanded="True">
+                        <ui:CardExpander Margin="0,8,0,8" Expanded="CardExpander_Expanded" Collapsed="CardExpander_Collapsed"
+                                         helpers:CardExpanderStateHelper.SyncedIsExpanded="{Binding IsExpanded, Mode=TwoWay}">
                             <ui:CardExpander.Header>
                                 <Grid>
                                     <Grid.ColumnDefinitions>

--- a/MyMoney/Views/Pages/BudgetPage.xaml.cs
+++ b/MyMoney/Views/Pages/BudgetPage.xaml.cs
@@ -109,5 +109,15 @@ namespace MyMoney.Views.Pages
                 ExpenseChart.Margin = _expenseChartWideMargin;
             }
         }
+
+        private void CardExpander_Expanded(object sender, RoutedEventArgs e)
+        {
+            ViewModel.WriteToDatabase();
+        }
+
+        private void CardExpander_Collapsed(object sender, RoutedEventArgs e)
+        {
+            ViewModel.WriteToDatabase();
+        }
     }
 }


### PR DESCRIPTION
Added IsExpanded property to BudgetExpenseCategory and a CardExpanderStateHelper to enable two-way binding of CardExpander's expanded state. Updated BudgetPage to use the helper and handle expanded/collapsed events to persist state via ViewModel.WriteToDatabase().

Closes #194 