### PR TITLE
Sort budgets in descending order on Budget page

### DIFF
--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -192,6 +192,12 @@ namespace MyMoney.ViewModels.Pages
             {
                 Budgets.Add(budget);
             }
+
+            // Sort according to date
+            var sortedBudgets = Budgets.OrderByDescending(x => x.BudgetDate).ToList();
+            Budgets.Clear();
+            foreach (var item in sortedBudgets)
+                Budgets.Add(item);
         }
 
         private void UpdateBudgetLists()


### PR DESCRIPTION
Budgets are now sorted in descending order by BudgetDate after being added. This improves the display order for users viewing their budgets.

Closes #208 