### PR TITLE
Add sorting for recent transactions in savings dialog

### DIFF
--- a/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
@@ -27,6 +27,15 @@ namespace MyMoney.ViewModels.ContentDialogs
         [ObservableProperty]
         private GridLength _editColumnWidth = new(200, GridUnitType.Pixel);
 
+        public void SortTransactions()
+        {
+            // Sort the transactions
+            var sortedTransactions = RecentTransactions.OrderByDescending(x => x.Date).ToList();
+            RecentTransactions.Clear();
+            foreach (var transaction in sortedTransactions)
+                RecentTransactions.Add(transaction);
+        }
+
         protected override void OnPropertyChanged(PropertyChangedEventArgs e)
         {
             base.OnPropertyChanged(e);

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -593,6 +593,7 @@ namespace MyMoney.ViewModels.Pages
                 CurrentBalance = CurrentBudget.BudgetSavingsCategories[SavingsCategoriesSelectedIndex].CurrentBalance,
                 RecentTransactions = CurrentBudget.BudgetSavingsCategories[SavingsCategoriesSelectedIndex].Transactions,
             };
+            viewModel.SortTransactions();
 
             _savingsCategoryDialogService.SetViewModel(viewModel);
             var result = await _savingsCategoryDialogService.ShowDialogAsync(_contentDialogService, "Edit Savings Category");


### PR DESCRIPTION
Introduced a SortTransactions method in SavingsCategoryDialogViewModel to order recent transactions by date descending. The method is now called when initializing the dialog in BudgetViewModel to ensure transactions are displayed in the correct order.

Closes #209 