### PR TITLE
Include uninstall icon in setup script

### DIFF
--- a/Installer/installer_builder.iss
+++ b/Installer/installer_builder.iss
@@ -19,6 +19,7 @@ AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 DefaultDirName={autopf}\{#MyAppName}
+UninstallDisplayIcon={app}\{#MyAppExeName}
 DisableProgramGroupPage=yes
 LicenseFile=..\LICENSE.txt
 ; Remove the following line to run in administrative install mode (install for all users.)


### PR DESCRIPTION
Currently the app icon is missing in the Windows Settings apps page. This adds a line to the Inno Setup script to fix that.