### PR TITLE
Fix compiler warnings

### DIFF
--- a/MyMoney.Core/Models/Transaction.cs
+++ b/MyMoney.Core/Models/Transaction.cs
@@ -37,7 +37,7 @@ public partial class Transaction : ObservableObject
     private string _memo;
 
     [ObservableProperty]
-    private string _transactionDetail;
+    private string _transactionDetail = "";
 
     [ObservableProperty]
     private DateTime _date;

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
@@ -112,7 +112,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockSavingsCategoryDialogService.Object
             );
 
-            _viewModel.OnPageNavigatedTo();
+            await _viewModel.OnPageNavigatedTo();
             _viewModel.CurrentBudget = _viewModel.Budgets[0];
 
             // Act
@@ -192,7 +192,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
                 _mockSavingsCategoryDialogService.Object
             );
 
-            _viewModel.OnPageNavigatedTo();
+            await _viewModel.OnPageNavigatedTo();
             _viewModel.CurrentBudget = _viewModel.Budgets[0];
 
             // Act

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -174,13 +174,22 @@ namespace MyMoney.ViewModels.Pages
 
             if (Budgets.Count > 0)
             {
-                await Application.Current.Dispatcher.InvokeAsync(() => {
+                await SelectCurrentBudget();
+            }
+
+            AddActualSpentToCurrentBudget();
+        }
+
+        private async Task SelectCurrentBudget()
+        {
+            if (Application.Current != null)
+            {
+                await Application.Current.Dispatcher.InvokeAsync(() =>
+                {
                     SelectedGroupedBudgetIndex = 0;
                     SelectedGroupedBudget = GroupedBudgets?.GetItemAt(0) as GroupedBudget;
                 });
             }
-
-            AddActualSpentToCurrentBudget();
         }
 
         public Task OnNavigatedToAsync()
@@ -936,6 +945,7 @@ namespace MyMoney.ViewModels.Pages
         private void LoadBudget(int index)
         {
             if (index == -1) return;
+            if (GroupedBudgets == null) return;
 
             // Load into current budget
             CurrentBudget = Budgets[index];


### PR DESCRIPTION
Fixed compiler warnings in BudgetViewModel and in the unit tests. Fixed a bug in the tests that caused them to fail when calling BudgetViewModel.OnPageNavigatedTo()