### PR TITLE
Set date on savings category balance carried forward transaction to last day previous month

### DIFF
--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -881,7 +881,7 @@ namespace MyMoney.ViewModels.Pages
                         BudgetSavingsCategory newSavingsCategory = (BudgetSavingsCategory)item.Clone();
 
                         // Add a new transaction that carries the balance forward
-                        Transaction balanceCarriedForward = new(newBudget.BudgetDate, "", 
+                        Transaction balanceCarriedForward = new(newBudget.BudgetDate.AddDays(-1), "", 
                             new Category() { Group = "Savings", Name = item.CategoryName },
                             item.CurrentBalance, "Balance carried forward")
                         {


### PR DESCRIPTION
This makes the balance carried forward transaction the oldest transaction in the savings category, showing up at the end of the list.

Closes #226 