### PR TITLE
Build native installers

### DIFF
--- a/Installer/installer_builder.iss
+++ b/Installer/installer_builder.iss
@@ -29,6 +29,9 @@ OutputBaseFilename=mymoney-setup-0.9.3-win-x64
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/Installer/installer_builder_arm64.iss
+++ b/Installer/installer_builder_arm64.iss
@@ -29,6 +29,9 @@ OutputBaseFilename=mymoney-setup-0.9.3-win-arm64
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Build native x64 and arm64 installers, previously the installer was x64 and required emulation to run on arm64.