### PR TITLE
Implement caching for budget reports

### DIFF
--- a/MyMoney.Core/Database/BudgetCollection.cs
+++ b/MyMoney.Core/Database/BudgetCollection.cs
@@ -105,7 +105,7 @@ namespace MyMoney.Core.Database
         /// Get the title for this month's budget. This works even if there is no budget for this month
         /// </summary>
         /// <returns>A string with the title of this month's budget</returns>
-        private static string GetCurrentBudgetName()
+        public static string GetCurrentBudgetName()
         {
             return DateTime.Today.ToString("MMMM, yyyy");
         }

--- a/MyMoney.Core/Database/DatabaseManager.cs
+++ b/MyMoney.Core/Database/DatabaseManager.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB;
+using System.Collections;
 
 namespace MyMoney.Core.Database
 {
@@ -8,9 +9,14 @@ namespace MyMoney.Core.Database
         public void WriteSettingsDictionary(string collectionName, Dictionary<string, string> collection);
         public List<T> GetCollection<T>(string collectionName);
         public Dictionary<string, string> GetSettingsDictionary(string collectionName);
+        public Dictionary<TKey, TValue> ReadDictionary<TKey, TValue>(string dictName) where TKey : notnull;
+        public void WriteDictionary<TKey, TValue>(string dictName, Dictionary<TKey, TValue> dictionary) where TKey : notnull;
     }
+
     public class DatabaseManager : IDatabaseManager
     {
+        private static readonly Lock _databaseLock = new();
+
         /// <summary>
         /// Read a collection from the database
         /// </summary>
@@ -19,16 +25,18 @@ namespace MyMoney.Core.Database
         /// <returns>A List<typeparamref name="T"/> containing the items in the collection</returns>
         public List<T> GetCollection<T>(string collectionName)
         {
-            using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
-
-            var collection = db.GetCollection<T>(collectionName);
-
-            // Create list from collection
             List<T> result = [];
 
-            for (int i = 1; i <= collection.Count(); i++)
+            lock (_databaseLock)
             {
-                result.Add(collection.FindById(i));
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+                var collection = db.GetCollection<T>(collectionName);
+
+                // Create list from collection
+                for (int i = 1; i <= collection.Count(); i++)
+                {
+                    result.Add(collection.FindById(i));
+                }
             }
 
             return result;
@@ -37,11 +45,15 @@ namespace MyMoney.Core.Database
         public Dictionary<string, string> GetSettingsDictionary(string collectionName)
         {
             Dictionary<string, string> dict = [];
+            List<KeyValuePair<string, string>> settingsList;
 
-            using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+            lock (_databaseLock)
+            {
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
 
-            var dbCollection = db.GetCollection<KeyValuePair<string, string>>(collectionName);
-            var settingsList = dbCollection.FindAll().ToList();
+                var dbCollection = db.GetCollection<KeyValuePair<string, string>>(collectionName);
+                settingsList = [.. dbCollection.FindAll()];
+            }
 
             foreach (var item in settingsList)
             {
@@ -53,36 +65,86 @@ namespace MyMoney.Core.Database
 
         public void WriteCollection<T>(string collectionName, List<T> collection)
         {
-            using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
-
-            var dbCollection = db.GetCollection<T>(collectionName);
-
-            // clear the database collection
-            dbCollection.DeleteAll();
-
-            // add the new items to the database
-            foreach (var item in collection)
+            lock (_databaseLock)
             {
-                dbCollection.Insert(item);
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+
+                var dbCollection = db.GetCollection<T>(collectionName);
+
+                // clear the database collection
+                dbCollection.DeleteAll();
+
+                // add the new items to the database
+                foreach (var item in collection)
+                {
+                    dbCollection.Insert(item);
+                }
             }
+
+            // Invalidate parts of the cache that were affected by this write
+            ReportsCache cache = new(this);
+            cache.InvalidateCacheOnWrite(collectionName);
         }
 
         public void WriteSettingsDictionary(string collectionName, Dictionary<string, string> collection)
         {
-            // Open or create a database file
-            using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+            lock (_databaseLock)
+            {
+                // Open or create a database file
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
 
-            // Get a list version
-            var dictList = collection.ToList();
+                // Get a list version
+                var dictList = collection.ToList();
 
-            // Clear the old collection
-            if (db.CollectionExists(collectionName))
-                db.DropCollection(collectionName);
+                // Clear the old collection
+                if (db.CollectionExists(collectionName))
+                    db.DropCollection(collectionName);
 
-            var dbCollection = db.GetCollection<KeyValuePair<string, string>>(collectionName);
+                var dbCollection = db.GetCollection<KeyValuePair<string, string>>(collectionName);
 
-            dbCollection.Insert(dictList);
-            dbCollection.EnsureIndex(x => x.Key);
+                dbCollection.Insert(dictList);
+                dbCollection.EnsureIndex(x => x.Key);
+            }
+        }
+
+        public Dictionary<TKey, TValue> ReadDictionary<TKey, TValue>(string dictName) where TKey: notnull
+        {
+            Dictionary<TKey, TValue> dict = [];
+
+            lock (_databaseLock)
+            {
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+
+                var dbCollection = db.GetCollection<KeyValuePair<TKey, TValue>>(dictName);
+                var settingsList = dbCollection.FindAll().ToList();
+
+                foreach (var item in settingsList)
+                {
+                    dict.TryAdd(item.Key, item.Value);
+                }
+            }
+            return dict;
+        }
+
+        public void WriteDictionary<TKey, TValue>(string dictName, Dictionary<TKey, TValue> dictionary) where TKey: notnull
+        {
+            lock (_databaseLock)
+            {
+                // Open or create a database file
+                using var db = new LiteDatabase(DataFileLocationGetter.GetDataFilePath());
+
+                // Get a list version
+                var dictList = dictionary.ToList();
+
+                // Clear the old collection
+                if (db.CollectionExists(dictName))
+                    db.DropCollection(dictName);
+
+                var dbCollection = db.GetCollection<KeyValuePair<TKey, TValue>>(dictName);
+
+                dbCollection.Insert(dictList);
+                dbCollection.EnsureIndex(x => x.Key);
+            }
         }
     }
 }

--- a/MyMoney.Core/Database/ReportsCache.cs
+++ b/MyMoney.Core/Database/ReportsCache.cs
@@ -64,6 +64,8 @@ namespace MyMoney.Core.Database
                     _cacheObjects.Remove(key);
                 }
             }
+
+            _dbManager.WriteDictionary(DICT_NAME, _cacheObjects);
         }
     }
 }

--- a/MyMoney.Core/Database/ReportsCache.cs
+++ b/MyMoney.Core/Database/ReportsCache.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MyMoney.Core.Database
+{
+    public class ReportsCache
+    {
+        private const string DICT_NAME = "ReportsCache";
+
+        private readonly Dictionary<string, object> _cacheObjects;
+
+        private readonly IDatabaseManager _dbManager;
+
+        public ReportsCache(IDatabaseManager databaseManager)
+        {
+            _dbManager = databaseManager;
+
+            // Load cache
+            _cacheObjects = _dbManager.ReadDictionary<string, object>(DICT_NAME);
+        }
+
+        public bool DoesKeyExist(string key)
+        {
+            return _cacheObjects.ContainsKey(key);
+        }
+
+        public void CacheObject(string key, object value)
+        {
+            _cacheObjects[key] = value;
+
+            // Save cache
+            _dbManager.WriteDictionary(DICT_NAME, _cacheObjects);
+        }
+
+        public bool RetrieveCachedObject(string key, out object? value)
+        {
+            var success = _cacheObjects.TryGetValue(key, out value);
+            return success;
+        }
+
+        public void UncacheObject(string key)
+        {
+            _cacheObjects.Remove(key);
+        }
+
+        public static string GenerateKeyForBudgetReportCache(DateTime budgetDate)
+        {
+            return "Budget-Report-" + budgetDate.ToString("MMMM-yyyy");
+        }
+
+        public void InvalidateCacheOnWrite(string collectionName)
+        {
+            if (collectionName == "Budgets" || collectionName == "Accounts")
+            {
+                // Invalidate all the budget reports
+                var keysToRemove = _cacheObjects.Keys
+                    .Where(key => key.StartsWith("Budget-Report-"))
+                    .ToList();
+                foreach (var key in keysToRemove)
+                {
+                    _cacheObjects.Remove(key);
+                }
+            }
+        }
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
@@ -2,6 +2,7 @@
 using Moq;
 using MyMoney.Core.Models;
 using System.Threading.Tasks;
+using MyMoney.Core.Database;
 
 namespace MyMoney.Tests.ViewModelTests
 {
@@ -73,6 +74,78 @@ namespace MyMoney.Tests.ViewModelTests
 
             // Make sure total is correct
             Assert.AreEqual(245m, viewModel.ReportTotal.Value);
+        }
+
+        [TestMethod]
+        public async Task Test_LoadReportData_Caching()
+        {
+            var mockDatabaseService = new Mock<Core.Database.IDatabaseManager>();
+
+            // Mock the ReportsCache to simulate cached data
+            var cachedData = new Dictionary<string, object>
+            {
+                {
+                    ReportsCache.GenerateKeyForBudgetReportCache(DateTime.Today),
+                    new Dictionary<string, object>
+                    {
+                        {
+                            "Income",
+                            new object[]
+                            {
+                                new BudgetReportItem
+                                {
+                                    Category = "Income 1",
+                                    Budgeted = new(500m),
+                                    Actual = new(300m),
+                                    Remaining = new(-200m)
+                                }
+                            }
+                        },
+                        {
+                            "Expenses",
+                            new object[]
+                            {
+                                new BudgetReportItem
+                                {
+                                    Category = "Expense 1",
+                                    Budgeted = new(400m),
+                                    Actual = new(450m),
+                                    Remaining = new(-50m)
+                                }
+                            }
+                        },
+                        {
+                            "Savings",
+                            new object[]
+                            {
+                                new SavingsCategoryReportItem
+                                {
+                                    Category = "Savings",
+                                    Saved = new(200m),
+                                    Balance = new(200m),
+                                    Spent = new(0m),
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            mockDatabaseService.Setup(service => service.ReadDictionary<string, object>("ReportsCache")).Returns(cachedData);
+
+            // Mock other required database calls
+            mockDatabaseService.Setup(service => service.GetCollection<Budget>("Budgets")).Returns([ new Budget() {BudgetDate = DateTime.Today, BudgetTitle = BudgetCollection.GetCurrentBudgetName()}]);
+            mockDatabaseService.Setup(service => service.GetCollection<Account>("Accounts")).Returns([]);
+
+            var viewModel = new BudgetReportsViewModel(mockDatabaseService.Object);
+            await viewModel.OnNavigatedToAsync();
+
+            // Verify that cached data is loaded correctly
+            Assert.HasCount(2, viewModel.IncomeItems); // One item plus the total item
+            Assert.AreEqual("Income 1", viewModel.IncomeItems[0].Category);
+            Assert.HasCount(2, viewModel.ExpenseItems); // One item plus the total item
+            Assert.AreEqual("Expense 1", viewModel.ExpenseItems[0].Category);
+            Assert.HasCount(1, viewModel.SavingsItems);
+            Assert.AreEqual("Savings", viewModel.SavingsItems[0].Category);
         }
     }
 }

--- a/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
@@ -1,6 +1,7 @@
 ﻿using MyMoney.ViewModels.Pages;
 using Moq;
 using MyMoney.Core.Models;
+using System.Threading.Tasks;
 
 namespace MyMoney.Tests.ViewModelTests
 {
@@ -8,7 +9,7 @@ namespace MyMoney.Tests.ViewModelTests
     public class BudgetReportsViewModelTest
     {
         [TestMethod]
-        public void Test_CalculateBudgetReport()
+        public async Task Test_CalculateBudgetReport()
         {
             var mockDatabaseService = new Mock<Core.Database.IDatabaseManager>();
             mockDatabaseService.Setup(service => service.GetCollection<Budget>("Budgets")).Returns(
@@ -33,6 +34,8 @@ namespace MyMoney.Tests.ViewModelTests
                 }
             ]);
 
+            mockDatabaseService.Setup(service => service.ReadDictionary<string, object>("ReportsCache")).Returns([]);
+
             mockDatabaseService.Setup(service => service.GetCollection<Account>("Accounts")).Returns(
                 [
                     new Account {
@@ -51,7 +54,8 @@ namespace MyMoney.Tests.ViewModelTests
                 ]);
 
             var viewModel = new BudgetReportsViewModel(mockDatabaseService.Object);
-            viewModel.CalculateReport(DateTime.Now);
+            await viewModel.OnNavigatedToAsync();
+            viewModel.SelectedBudget = viewModel.Budgets[viewModel.SelectedBudgetIndex];
 
             Assert.AreEqual(3, viewModel.IncomeItems.Count);
             Assert.AreEqual(5, viewModel.ExpenseItems.Count);

--- a/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
@@ -55,7 +55,6 @@ namespace MyMoney.Tests.ViewModelTests
 
             var viewModel = new BudgetReportsViewModel(mockDatabaseService.Object);
             await viewModel.OnNavigatedToAsync();
-            viewModel.SelectedBudget = viewModel.Budgets[viewModel.SelectedBudgetIndex];
 
             Assert.AreEqual(3, viewModel.IncomeItems.Count);
             Assert.AreEqual(5, viewModel.ExpenseItems.Count);

--- a/MyMoney/ViewModels/Pages/BudgetReportsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetReportsViewModel.cs
@@ -214,11 +214,80 @@ namespace MyMoney.ViewModels.Pages
         private (List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) LoadReportData(DateTime date)
         {
             lock (_databaseReaderLock)
+            {
+                // Check to see if data is cached
+                ReportsCache cache = new(_databaseReader);
+                string key = ReportsCache.GenerateKeyForBudgetReportCache(Budgets[SelectedBudgetIndex].BudgetDate);
+                if (cache.DoesKeyExist(key))
+                {
+                    // Read cache data
+                    Dictionary<string, object> cachedReport;
+                    cache.RetrieveCachedObject(key, out object? cachedItem);
+                    if (cachedItem != null)
+                    {
+                        try
+                        {
+                            cachedReport = (Dictionary<string, object>)cachedItem;
+
+                            // Ensure the correct items are in the cached report
+                            if (cachedReport.TryGetValue("Income", out object? cachedIncomeObject) && 
+                                cachedReport.TryGetValue("Expenses", out object? cachedExpensesObject) &&
+                                cachedReport.TryGetValue("Savings", out object? cachedSavingsObject))
+                            {
+                                // convert to arrays of object
+                                var cachedIncomeObjectArray = (object[])cachedIncomeObject;
+                                var cachedExpenseObjectArray = (object[])cachedExpensesObject;
+                                var cachedSavingsObjectArray = (object[])cachedSavingsObject;
+
+                                // Load the cached data and return it
+                                List<BudgetReportItem> cachedIncome = [];
+                                foreach (var item in cachedIncomeObjectArray)
+                                {
+                                    cachedIncome.Add((BudgetReportItem)item);
+                                }
+
+                                List<BudgetReportItem> cachedExpenses = [];
+                                foreach (var item in cachedExpenseObjectArray)
+                                {
+                                    cachedExpenses.Add((BudgetReportItem)item);
+                                }
+
+                                List<SavingsCategoryReportItem> cachedSavings = [];
+                                foreach (var item in cachedSavingsObjectArray)
+                                {
+                                    cachedSavings.Add((SavingsCategoryReportItem)item);
+                                }
+
+                                if (cachedIncome.Count > 0 && cachedExpenses.Count > 0 && cachedSavings.Count > 0)
+                                    return (cachedIncome, cachedExpenses, cachedSavings);                                
+                            }
+                        }
+                        catch (Exception) 
+                        {
+                            // Cache is invalid, calculate report from scratch
+                            cache.UncacheObject(key);
+                        }
+                    }
+                }
+
+                // Load data and cache it
+                var calculatedIncomeItems = BudgetReportCalculator.CalculateIncomeReportItems(date, _databaseReader);
+                var calculatedExpenseItems = BudgetReportCalculator.CalculateExpenseReportItems(date, _databaseReader);
+                var calulatedSavingsItems = BudgetReportCalculator.CalculateSavingsReportItems(date, _databaseReader);
+
+                Dictionary<string, object> reportToCache = [];
+                reportToCache["Income"] = calculatedIncomeItems;
+                reportToCache["Expenses"] = calculatedExpenseItems;
+                reportToCache["Savings"] = calulatedSavingsItems;
+
+                cache.CacheObject(key, reportToCache);
+
                 return (
-                    BudgetReportCalculator.CalculateIncomeReportItems(date, _databaseReader),
-                    BudgetReportCalculator.CalculateExpenseReportItems(date, _databaseReader),
-                    BudgetReportCalculator.CalculateSavingsReportItems(date, _databaseReader)
+                    calculatedIncomeItems,
+                    calculatedExpenseItems,
+                    calulatedSavingsItems
                 );
+            }
         }
 
         private void UpdateReportCollections((List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) data)

--- a/MyMoney/ViewModels/Pages/BudgetReportsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetReportsViewModel.cs
@@ -128,7 +128,6 @@ namespace MyMoney.ViewModels.Pages
         #region Fields
 
         private readonly IDatabaseManager _databaseReader;
-        private readonly Lock _databaseReaderLock = new();
 
         #endregion
 
@@ -191,9 +190,7 @@ namespace MyMoney.ViewModels.Pages
 
         private void LoadBudgets()
         {
-            BudgetCollection budgetCollection;
-            lock (_databaseReaderLock)
-                budgetCollection = new BudgetCollection(_databaseReader);
+            BudgetCollection budgetCollection = new(_databaseReader);
 
             var unsortedBudgets = new ObservableCollection<Budget>(budgetCollection.Budgets);
             Budgets = new ObservableCollection<Budget>(unsortedBudgets.OrderByDescending(o => o.BudgetDate));
@@ -213,81 +210,79 @@ namespace MyMoney.ViewModels.Pages
 
         private (List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) LoadReportData(DateTime date)
         {
-            lock (_databaseReaderLock)
+            // Check to see if data is cached
+            ReportsCache cache = new(_databaseReader);
+            string key = ReportsCache.GenerateKeyForBudgetReportCache(Budgets[SelectedBudgetIndex].BudgetDate);
+            if (cache.DoesKeyExist(key))
             {
-                // Check to see if data is cached
-                ReportsCache cache = new(_databaseReader);
-                string key = ReportsCache.GenerateKeyForBudgetReportCache(Budgets[SelectedBudgetIndex].BudgetDate);
-                if (cache.DoesKeyExist(key))
+                // Read cache data
+                Dictionary<string, object> cachedReport;
+                cache.RetrieveCachedObject(key, out object? cachedItem);
+                if (cachedItem != null)
                 {
-                    // Read cache data
-                    Dictionary<string, object> cachedReport;
-                    cache.RetrieveCachedObject(key, out object? cachedItem);
-                    if (cachedItem != null)
+                    try
                     {
-                        try
-                        {
-                            cachedReport = (Dictionary<string, object>)cachedItem;
+                        cachedReport = (Dictionary<string, object>)cachedItem;
 
-                            // Ensure the correct items are in the cached report
-                            if (cachedReport.TryGetValue("Income", out object? cachedIncomeObject) && 
-                                cachedReport.TryGetValue("Expenses", out object? cachedExpensesObject) &&
-                                cachedReport.TryGetValue("Savings", out object? cachedSavingsObject))
+                        // Ensure the correct items are in the cached report
+                        if (cachedReport.TryGetValue("Income", out object? cachedIncomeObject) &&
+                            cachedReport.TryGetValue("Expenses", out object? cachedExpensesObject) &&
+                            cachedReport.TryGetValue("Savings", out object? cachedSavingsObject))
+                        {
+                            // convert to arrays of object
+                            var cachedIncomeObjectArray = (object[])cachedIncomeObject;
+                            var cachedExpenseObjectArray = (object[])cachedExpensesObject;
+                            var cachedSavingsObjectArray = (object[])cachedSavingsObject;
+
+                            // Load the cached data and return it
+                            List<BudgetReportItem> cachedIncome = [];
+                            foreach (var item in cachedIncomeObjectArray)
                             {
-                                // convert to arrays of object
-                                var cachedIncomeObjectArray = (object[])cachedIncomeObject;
-                                var cachedExpenseObjectArray = (object[])cachedExpensesObject;
-                                var cachedSavingsObjectArray = (object[])cachedSavingsObject;
-
-                                // Load the cached data and return it
-                                List<BudgetReportItem> cachedIncome = [];
-                                foreach (var item in cachedIncomeObjectArray)
-                                {
-                                    cachedIncome.Add((BudgetReportItem)item);
-                                }
-
-                                List<BudgetReportItem> cachedExpenses = [];
-                                foreach (var item in cachedExpenseObjectArray)
-                                {
-                                    cachedExpenses.Add((BudgetReportItem)item);
-                                }
-
-                                List<SavingsCategoryReportItem> cachedSavings = [];
-                                foreach (var item in cachedSavingsObjectArray)
-                                {
-                                    cachedSavings.Add((SavingsCategoryReportItem)item);
-                                }
-
-                                if (cachedIncome.Count > 0 && cachedExpenses.Count > 0 && cachedSavings.Count > 0)
-                                    return (cachedIncome, cachedExpenses, cachedSavings);                                
+                                cachedIncome.Add((BudgetReportItem)item);
                             }
-                        }
-                        catch (Exception) 
-                        {
-                            // Cache is invalid, calculate report from scratch
-                            cache.UncacheObject(key);
+
+                            List<BudgetReportItem> cachedExpenses = [];
+                            foreach (var item in cachedExpenseObjectArray)
+                            {
+                                cachedExpenses.Add((BudgetReportItem)item);
+                            }
+
+                            List<SavingsCategoryReportItem> cachedSavings = [];
+                            foreach (var item in cachedSavingsObjectArray)
+                            {
+                                cachedSavings.Add((SavingsCategoryReportItem)item);
+                            }
+
+                            if (cachedIncome.Count > 0 && cachedExpenses.Count > 0 && cachedSavings.Count > 0)
+                                return (cachedIncome, cachedExpenses, cachedSavings);
                         }
                     }
+                    catch (Exception)
+                    {
+                        // Cache is invalid, calculate report from scratch
+                        cache.UncacheObject(key);
+                    }
                 }
-
-                // Load data and cache it
-                var calculatedIncomeItems = BudgetReportCalculator.CalculateIncomeReportItems(date, _databaseReader);
-                var calculatedExpenseItems = BudgetReportCalculator.CalculateExpenseReportItems(date, _databaseReader);
-                var calulatedSavingsItems = BudgetReportCalculator.CalculateSavingsReportItems(date, _databaseReader);
-
-                Dictionary<string, object> reportToCache = [];
-                reportToCache["Income"] = calculatedIncomeItems;
-                reportToCache["Expenses"] = calculatedExpenseItems;
-                reportToCache["Savings"] = calulatedSavingsItems;
-
-                cache.CacheObject(key, reportToCache);
-
-                return (
-                    calculatedIncomeItems,
-                    calculatedExpenseItems,
-                    calulatedSavingsItems
-                );
             }
+
+            // Load data and cache it
+            var calculatedIncomeItems = BudgetReportCalculator.CalculateIncomeReportItems(date, _databaseReader);
+            var calculatedExpenseItems = BudgetReportCalculator.CalculateExpenseReportItems(date, _databaseReader);
+            var calulatedSavingsItems = BudgetReportCalculator.CalculateSavingsReportItems(date, _databaseReader);
+
+            Dictionary<string, object> reportToCache = [];
+            reportToCache["Income"] = calculatedIncomeItems;
+            reportToCache["Expenses"] = calculatedExpenseItems;
+            reportToCache["Savings"] = calulatedSavingsItems;
+
+            cache.CacheObject(key, reportToCache);
+
+            return (
+                calculatedIncomeItems,
+                calculatedExpenseItems,
+                calulatedSavingsItems
+            );
+
         }
 
         private void UpdateReportCollections((List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) data)
@@ -387,18 +382,18 @@ namespace MyMoney.ViewModels.Pages
 
         private static ISeries[] CreatePieSeries(Dictionary<string, double> totals)
         {
-            return totals.Select(item => 
-                new PieSeries<double> 
-                { 
-                    Values = [item.Value], 
-                    Name = item.Key 
+            return totals.Select(item =>
+                new PieSeries<double>
+                {
+                    Values = [item.Value],
+                    Name = item.Key
                 }).ToArray();
         }
 
         private void UpdateChartsTheme()
         {
-            ChartTextColor = ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Light 
-                ? LightTextColor 
+            ChartTextColor = ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Light
+                ? LightTextColor
                 : DarkTextColor;
 
             var textPaint = new SolidColorPaint(ChartTextColor);

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -127,10 +127,6 @@ namespace MyMoney.ViewModels.Pages
             }
         }
 
-        // Lock for the database
-        private readonly object _databaseLockObject = new();
-
-
         // Content dialog service
         private readonly IContentDialogService _contentDialogService;
         private readonly IMessageBoxService _messageBoxService;
@@ -194,10 +190,7 @@ namespace MyMoney.ViewModels.Pages
         {
             Budgets.Clear();
 
-            List<Budget> budgetCollection;
-            
-            lock(_databaseLockObject)
-                budgetCollection = _databaseManager.GetCollection<Budget>("Budgets");
+            List<Budget> budgetCollection = _databaseManager.GetCollection<Budget>("Budgets");
 
             foreach (var budget in budgetCollection.OfType<Budget>())
             {
@@ -267,9 +260,7 @@ namespace MyMoney.ViewModels.Pages
         public void WriteToDatabase()
         {
             if (CurrentBudget == null) return;
-            
-            lock (_databaseLockObject)
-                _databaseManager.WriteCollection("Budgets", Budgets.ToList());
+            _databaseManager.WriteCollection("Budgets", Budgets.ToList());
         }
 
         private void UpdateListViewTotals()
@@ -1053,12 +1044,10 @@ namespace MyMoney.ViewModels.Pages
             List<BudgetReportItem> expenseItems;
             List<SavingsCategoryReportItem> savingsItems;
 
-            lock (_databaseLockObject)
-            {
-                incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(budgetDate, _databaseManager);
-                expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(budgetDate, _databaseManager);
-                savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(budgetDate, _databaseManager);
-            }
+            incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(budgetDate, _databaseManager);
+            expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(budgetDate, _databaseManager);
+            savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(budgetDate, _databaseManager);
+            
 
             Application.Current.Dispatcher.BeginInvoke(() =>
             {

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -1040,22 +1040,15 @@ namespace MyMoney.ViewModels.Pages
             var budget = CurrentBudget;
             var budgetDate = budget.BudgetDate;
 
-            List<BudgetReportItem> incomeItems;
-            List<BudgetReportItem> expenseItems;
-            List<SavingsCategoryReportItem> savingsItems;
-
-            incomeItems = BudgetReportCalculator.CalculateIncomeReportItems(budgetDate, _databaseManager);
-            expenseItems = BudgetReportCalculator.CalculateExpenseReportItems(budgetDate, _databaseManager);
-            savingsItems = BudgetReportCalculator.CalculateSavingsReportItems(budgetDate, _databaseManager);
-            
+            var (income, expenses, savings) = BudgetReportCalculator.CalculateBudgetReport(budgetDate, _databaseManager);
 
             Application.Current.Dispatcher.BeginInvoke(() =>
             {
                 if (CurrentBudget == null || CurrentBudget != budget) return; // Ensure budget hasn't changed
 
-                UpdateIncomeActuals(incomeItems);
-                UpdateSavingsActuals(savingsItems);
-                UpdateExpenseActuals(expenseItems);
+                UpdateIncomeActuals(income);
+                UpdateSavingsActuals(savings);
+                UpdateExpenseActuals(expenses);
             });
         }
 

--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -112,7 +112,6 @@ namespace MyMoney.ViewModels.Pages
         #endregion
 
         private readonly IDatabaseManager _databaseReader;
-        private readonly object _databaseLockObject = new();
         private readonly Lock _incomeItemsLock = new();
         private readonly Lock _expenseItemsLock = new();
         private readonly Lock _savingsItemsLock = new();
@@ -144,14 +143,11 @@ namespace MyMoney.ViewModels.Pages
 
         private (List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) LoadReportItems()
         {
-            lock (_databaseLockObject)
-            {
-                return (
-                    BudgetReportCalculator.CalculateIncomeReportItems(_databaseReader),
-                    BudgetReportCalculator.CalculateExpenseReportItems(_databaseReader),
-                    BudgetReportCalculator.CalculateSavingsReportItems(DateTime.Today, _databaseReader)
-                );
-            }
+            return (
+                BudgetReportCalculator.CalculateIncomeReportItems(_databaseReader),
+                BudgetReportCalculator.CalculateExpenseReportItems(_databaseReader),
+                BudgetReportCalculator.CalculateSavingsReportItems(DateTime.Today, _databaseReader)
+            );
         }
 
         private void UpdateReportCollections((List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) items)
@@ -266,11 +262,7 @@ namespace MyMoney.ViewModels.Pages
         {
             Accounts.Clear();
 
-            List<Account> accounts;
-            lock (_databaseLockObject)
-            {
-                accounts = _databaseReader.GetCollection<Account>("Accounts");
-            }
+            List<Account> accounts = _databaseReader.GetCollection<Account>("Accounts");
 
             foreach (var account in accounts)
             {

--- a/MyMoney/ViewModels/Pages/DashboardViewModel.cs
+++ b/MyMoney/ViewModels/Pages/DashboardViewModel.cs
@@ -143,11 +143,7 @@ namespace MyMoney.ViewModels.Pages
 
         private (List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) LoadReportItems()
         {
-            return (
-                BudgetReportCalculator.CalculateIncomeReportItems(_databaseReader),
-                BudgetReportCalculator.CalculateExpenseReportItems(_databaseReader),
-                BudgetReportCalculator.CalculateSavingsReportItems(DateTime.Today, _databaseReader)
-            );
+            return BudgetReportCalculator.CalculateBudgetReport(DateTime.Today, _databaseReader);
         }
 
         private void UpdateReportCollections((List<BudgetReportItem> income, List<BudgetReportItem> expense, List<SavingsCategoryReportItem> savings) items)

--- a/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
+++ b/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
@@ -15,6 +15,8 @@ namespace MyMoney.Views.Controls
         public BudgetReportControl()
         {
             InitializeComponent();
+
+            ExpenseItems ??= [];   
         }
 
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BudgetReportControl), new PropertyMetadata("Budget Report"));
@@ -56,7 +58,7 @@ namespace MyMoney.Views.Controls
 
         public static readonly DependencyProperty ExpenseItemsProperty = DependencyProperty.Register("ExpenseItems",
             typeof(ObservableCollection<BudgetReportItem>), typeof(BudgetReportControl),
-            new FrameworkPropertyMetadata(new ObservableCollection<BudgetReportItem>(),
+            new FrameworkPropertyMetadata(null,
                 FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnExpenseItemsChanged));
 
         /// <summary>
@@ -100,6 +102,7 @@ namespace MyMoney.Views.Controls
         {
             get
             {
+                ExpenseItems ??= [];
                 ListCollectionView listCollectionView = new(ExpenseItems);
                 listCollectionView.GroupDescriptions.Add(new PropertyGroupDescription("Group"));
                 return listCollectionView;

--- a/MyMoney/Views/Pages/BudgetReportsPage.xaml
+++ b/MyMoney/Views/Pages/BudgetReportsPage.xaml
@@ -30,7 +30,7 @@
         </Grid.RowDefinitions>
 
         <ui:Card x:Name="BudgetsCard" Grid.Column="0" Grid.RowSpan="2" VerticalAlignment="Stretch" VerticalContentAlignment="Stretch" Margin="0,0,8,24">
-            <ui:ListView x:Name="BudgetsListView" ItemsSource="{Binding ViewModel.Budgets}" SelectedItem="{Binding ViewModel.SelectedBudget}"
+            <ui:ListView x:Name="BudgetsListView" ItemsSource="{Binding ViewModel.Budgets}" SelectedItem="{Binding ViewModel.SelectedBudget, Mode=TwoWay}"
                          SelectedIndex="{Binding ViewModel.SelectedBudgetIndex}">
                 <ui:ListView.ItemTemplate>
                     <DataTemplate>


### PR DESCRIPTION
This feature caches budget reports in the database after they are calculated. This makes so that the report doesn't need to be recalculated every time it is loaded. The cache is cleared every time any of the collections the report depends on is written to.