### PR TITLE
Fix scrolling issue when the mouse pointer is over a GridView column header

### DIFF
--- a/MyMoney/Helpers/VisualTreeHelpers.cs
+++ b/MyMoney/Helpers/VisualTreeHelpers.cs
@@ -1,0 +1,20 @@
+﻿using System.Windows.Media;
+
+namespace MyMoney.Helpers
+{
+    public static class VisualTreeHelpers
+    {
+        public static T? FindAncestor<T>(this DependencyObject current)
+            where T : DependencyObject
+        {
+            while (current != null)
+            {
+                if (current is T correctlyTyped)
+                    return correctlyTyped;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+            return null;
+        }
+    }
+}

--- a/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
+++ b/MyMoney/Views/Controls/BudgetReportControl.xaml.cs
@@ -4,6 +4,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
+using MyMoney.Helpers;
 
 namespace MyMoney.Views.Controls
 {
@@ -16,7 +18,11 @@ namespace MyMoney.Views.Controls
         {
             InitializeComponent();
 
-            ExpenseItems ??= [];   
+            ExpenseItems ??= [];
+            // Listen for MouseWheel on *all* column headers inside this control
+            AddHandler(GridViewColumnHeader.PreviewMouseWheelEvent,
+                       new MouseWheelEventHandler(GridViewColumnHeader_PreviewMouseWheel),
+                       handledEventsToo: true);
         }
 
         public static readonly DependencyProperty TitleProperty = DependencyProperty.Register("Title", typeof(string), typeof(BudgetReportControl), new PropertyMetadata("Budget Report"));
@@ -170,6 +176,22 @@ namespace MyMoney.Views.Controls
         {
             get { return (int)GetValue(RemainingColumnWidthProperty); }
             set { SetValue(RemainingColumnWidthProperty, value); }
+        }
+
+        private void GridViewColumnHeader_PreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
+        {
+            // Don't let the header eat the scroll event
+            e.Handled = true;
+
+            var scrollViewer = (sender as DependencyObject)?.FindAncestor<ScrollViewer>();
+            if (scrollViewer != null)
+            {
+                scrollViewer.RaiseEvent(new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta)
+                {
+                    RoutedEvent = UIElement.MouseWheelEvent,
+                    Source = sender
+                });
+            }
         }
     }
 }

--- a/MyMoney/Views/Pages/BudgetPage.xaml.cs
+++ b/MyMoney/Views/Pages/BudgetPage.xaml.cs
@@ -5,6 +5,7 @@ using MyMoney.ViewModels.Pages;
 using System.Windows.Controls;
 using Wpf.Ui.Abstractions.Controls;
 using Wpf.Ui.Controls;
+using System.Windows.Input;
 
 namespace MyMoney.Views.Pages
 {
@@ -41,6 +42,11 @@ namespace MyMoney.Views.Pages
             _chartPanelWideMargin = ChartsPanel.Margin;
             _incomeChartWideMargin = IncomeChart.Margin;
             _expenseChartWideMargin= ExpenseChart.Margin;
+
+            // Listen for MouseWheel on *all* column headers inside this page
+            AddHandler(GridViewColumnHeader.PreviewMouseWheelEvent,
+                       new MouseWheelEventHandler(GridViewColumnHeader_PreviewMouseWheel),
+                       handledEventsToo: true);
         }
 
         private void ListView_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -115,6 +121,22 @@ namespace MyMoney.Views.Pages
         private void CardExpander_Expanded(object sender, RoutedEventArgs e)
         {
             ViewModel.WriteToDatabase();
+        }
+
+        private void GridViewColumnHeader_PreviewMouseWheel(object sender, System.Windows.Input.MouseWheelEventArgs e)
+        {
+            // Don't let the header eat the scroll event
+            e.Handled = true;
+
+            var scrollViewer = (sender as DependencyObject)?.FindAncestor<ScrollViewer>();
+            if (scrollViewer != null)
+            {
+                scrollViewer.RaiseEvent(new MouseWheelEventArgs(e.MouseDevice, e.Timestamp, e.Delta)
+                {
+                    RoutedEvent = UIElement.MouseWheelEvent,
+                    Source = sender
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes the problem where the page will not scroll if the mouse pointer is over a GridView column header.