### PR TITLE
Show exact values on net worth chart without curves

### DIFF
--- a/MyMoney/ViewModels/Pages/ReportsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/ReportsViewModel.cs
@@ -175,6 +175,7 @@ namespace MyMoney.ViewModels.Pages
                     GeometrySize = 0,
                     Stroke = new SolidColorPaint(new SKColor(accentColor.R, accentColor.G, accentColor.B), 4),
                     Fill = new SolidColorPaint(new SKColor(lighterAccentColor.R, lighterAccentColor.G, lighterAccentColor.B, 175)),
+                    LineSmoothness = 0,
                 }
             ];
 


### PR DESCRIPTION
Set the line smoothness property on the networth chart to zero, so that all lines are sharp with no curves.
Fixes #252 