### PR TITLE
Prevent application from changing theme automatically

### DIFF
--- a/MyMoney/Views/Windows/MainWindow.xaml.cs
+++ b/MyMoney/Views/Windows/MainWindow.xaml.cs
@@ -26,8 +26,6 @@ namespace MyMoney.Views.Windows
             ViewModel = viewModel;
             DataContext = this;
 
-            SystemThemeWatcher.Watch(this);
-
             InitializeComponent();
             SetPageService(pageService);
 
@@ -67,7 +65,11 @@ namespace MyMoney.Views.Windows
                     // set the color dynamic resources
                     Application.Current.Resources["LayerFillColorDefaultColor"] = Application.Current.Resources["LayerFillColorDefaultColorDark"];
                 }
-                    
+            }
+            else
+            {
+                // Set to system theme by default
+                ApplicationThemeManager.ApplySystemTheme();
             }
         }
 


### PR DESCRIPTION
This removes the theme watcher from the main window. The theme watcher sometimes changes the theme to the system theme after the application has been running for a few minutes. Now, if no theme is found in the database, it is set to the system default.