### PR TITLE
Stop saving budget item selected index to the database

### DIFF
--- a/MyMoney.Core/Models/BudgetExpenseCategory.cs
+++ b/MyMoney.Core/Models/BudgetExpenseCategory.cs
@@ -1,10 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using LiteDB;
 
 namespace MyMoney.Core.Models
 {
@@ -20,7 +16,8 @@ namespace MyMoney.Core.Models
         private ObservableCollection<BudgetItem> _subItems = [];
 
         [ObservableProperty]
-        private int _selectedSubItemIndex = 1;
+        [property: BsonIgnore]
+        private int _selectedSubItemIndex = -1;
 
         [ObservableProperty]
         private bool _isExpanded = true;

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
@@ -131,7 +131,7 @@ public class DeleteExpenseItemTests
             }
         };
         _viewModel.CurrentBudget = budget;
-        _viewModel.ExpenseItemsSelectedIndex = 1; // Delete middle item
+        _viewModel.CurrentBudget.BudgetExpenseItems[0].SelectedSubItemIndex = 1; // Select "Category 2"
 
         _messageBoxServiceMock.Setup(x => x.ShowAsync(
             It.IsAny<string>(),

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -62,13 +62,13 @@ namespace MyMoney.ViewModels.Pages
         private SKColor _chartTextColor = new(0x33, 0x33, 0x33);
 
         [ObservableProperty]
-        private int _incomeItemsSelectedIndex;
+        private int _incomeItemsSelectedIndex = -1;
 
         [ObservableProperty]
-        private int _savingsCategoriesSelectedIndex;
+        private int _savingsCategoriesSelectedIndex = -1;
 
         [ObservableProperty]
-        private int _expenseItemsSelectedIndex;
+        private int _expenseItemsSelectedIndex = -1;
 
         [ObservableProperty]
         private Currency _incomeTotal = new(0m);


### PR DESCRIPTION
Set the default value of the budget items selected index to -1, to prevent any items from being selected on startup. Added a `BsonIgnore` attribute to the `SelectedSubItemIndex` property in the budget expense category model to prevent the property from being saved to the database.