### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,6 @@
 name: .NET Core Desktop
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jm6271/MyMoney/security/code-scanning/1](https://github.com/jm6271/MyMoney/security/code-scanning/1)

To fix the problem, add a `permissions` block specifying the minimal required GitHub token privilege: `contents: read`. This can be added either at the root of the workflow file (applies to all jobs), or within the job (`run-unit-tests`) itself. Since this workflow only contains one job, placing it at the top (root) is optimal for clarity and easy future extension. No other region of the file or functionality needs to be updated for the fix; simply add the block immediately after the `name:` or before/after the `on:` section.

**Specifically**:  
- Edit `.github/workflows/dotnet-desktop.yml`
- Insert a `permissions:` block near the top (conventionally after `name:`, before `on:`)
- Set `contents: read`

No methods, imports, or additional definitions required. Only a YAML syntax update.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
