### PR TITLE
Use `InformationalVersion` instead of `AssemblyVersion` for displaying version in settings

### DIFF
--- a/MyMoney/MyMoney.csproj
+++ b/MyMoney/MyMoney.csproj
@@ -8,8 +8,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Title>MyMoney</Title>
-    <AssemblyVersion>0.10.1</AssemblyVersion>
-    <FileVersion>0.10.1</FileVersion>
+    <AssemblyVersion>0.10.3</AssemblyVersion>
+    <FileVersion>0.10.3</FileVersion>
+	<InformationalVersion>0.10.3-beta</InformationalVersion>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
   <ItemGroup>

--- a/MyMoney/ViewModels/Pages/SettingsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/SettingsViewModel.cs
@@ -124,7 +124,8 @@ namespace MyMoney.ViewModels.Pages
 
         private static string GetVersionString()
         {
-            var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? string.Empty;
+            var version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion?.Split('+')[0];
             return $"MyMoney - {version}";
         }
 


### PR DESCRIPTION
Set the `InformationalVersion` property in `MyMoney.csproj` and retrieve it at runtime with reflection to display on the settings page.