### PR TITLE
Fix budget expense item edits modifying multiple budgets after new budget is created

### DIFF
--- a/MyMoney.Core/Models/BudgetExpenseCategory.cs
+++ b/MyMoney.Core/Models/BudgetExpenseCategory.cs
@@ -4,7 +4,7 @@ using LiteDB;
 
 namespace MyMoney.Core.Models
 {
-    public partial class BudgetExpenseCategory : ObservableObject
+    public partial class BudgetExpenseCategory : ObservableObject, ICloneable
     {
         [ObservableProperty]
         private int _id = 0;
@@ -33,6 +33,17 @@ namespace MyMoney.Core.Models
                 }
                 return new Currency(total);
             }
+        }
+
+        public object Clone()
+        {
+            return new BudgetExpenseCategory()
+            {
+                Id = this.Id,
+                CategoryName = this.CategoryName,
+                SubItems = new ObservableCollection<BudgetItem>(this.SubItems.Select(item => (BudgetItem)item.Clone())),
+                IsExpanded = this.IsExpanded
+            };
         }
     }
 }

--- a/MyMoney.Core/Models/BudgetItem.cs
+++ b/MyMoney.Core/Models/BudgetItem.cs
@@ -7,8 +7,19 @@ using System.Threading.Tasks;
 
 namespace MyMoney.Core.Models
 {
-    public partial class BudgetItem : ObservableObject
+    public partial class BudgetItem : ObservableObject, ICloneable
     {
+        public object Clone()
+        {
+            return new BudgetItem()
+            {
+                Id = this.Id,
+                Category = this.Category,
+                Amount = new Currency(this.Amount.Value),
+                Actual = new Currency(this.Actual.Value)
+            };
+        }
+    
         [ObservableProperty]
         private int _id = 0;
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -859,7 +859,7 @@ namespace MyMoney.ViewModels.Pages
 
                     foreach (var item in CurrentBudget.BudgetExpenseItems)
                     {
-                        newBudget.BudgetExpenseItems.Add(item);
+                        newBudget.BudgetExpenseItems.Add((BudgetExpenseCategory)item.Clone());
                     }
                 }
 


### PR DESCRIPTION
This does a deep copy when creating a new budget from an old one, so that the `SubItems` collection won't be shallow copied and then shared between the two budgets. 