### PR TITLE
Correctly set foreground for LeftToBudget value after theme change

### DIFF
--- a/MyMoney/Helpers/NegativeCurrencyToRedColorConverter.cs
+++ b/MyMoney/Helpers/NegativeCurrencyToRedColorConverter.cs
@@ -21,14 +21,7 @@ namespace MyMoney.Helpers
             }
             else
             {
-                if (ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Light)
-                {
-                    return new SolidColorBrush(Color.FromArgb(255, 0, 0, 0));
-                }
-                else
-                {
-                    return new SolidColorBrush(Color.FromArgb(255, 255, 255, 255));
-                }
+                return (SolidColorBrush)Application.Current.Resources["TextFillColorPrimaryBrush"];
             }
         }
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -145,6 +145,9 @@ namespace MyMoney.ViewModels.Pages
 
             if (Budgets.Count > 0)
                 SelectCurrentBudget();
+
+            // Fire property changed so that colors update if the theme was changed
+            OnPropertyChanged(nameof(LeftToBudget));
         }
 
         public Task OnNavigatedFromAsync()


### PR DESCRIPTION
After a theme change, the foreground color of the 'Left to budget' value on the budget page did not change, creating a black on black or white on white label. This fires a property changed event for the Left to budget value on page navigated to, so that the converter will run again and return the correct foreground.