### PR TITLE
Fix warnings in test project

### DIFF
--- a/MyMoney.Tests/AssemblyInfo.cs
+++ b/MyMoney.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteAccount.cs
@@ -72,7 +72,7 @@ public class DeleteAccountTests
         _viewModel.DeleteAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.Accounts.Count);
+        Assert.HasCount(1, _viewModel.Accounts);
     }
 
     [TestMethod]
@@ -94,7 +94,7 @@ public class DeleteAccountTests
         _viewModel.DeleteAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.Accounts.Count);
+        Assert.HasCount(1, _viewModel.Accounts);
         Assert.AreEqual(1, _viewModel.Accounts[0].Id);
         Assert.AreEqual("Test2", _viewModel.Accounts[0].AccountName);
     }

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteTransaction.cs
@@ -94,7 +94,7 @@ public class DeleteTransactionTest
         _viewModel.DeleteTransactionCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(1, account.Transactions.Count);
+        Assert.HasCount(1, account.Transactions);
         Assert.AreEqual(1000m, account.Total.Value);
     }
 
@@ -119,7 +119,7 @@ public class DeleteTransactionTest
         _viewModel.DeleteTransactionCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(0, account.Transactions.Count);
+        Assert.HasCount(0, account.Transactions);
         Assert.AreEqual(900m, account.Total.Value); // 1000 - 100
     }
 
@@ -144,7 +144,7 @@ public class DeleteTransactionTest
         _viewModel.DeleteTransactionCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(0, account.Transactions.Count);
+        Assert.IsEmpty(account.Transactions);
         Assert.AreEqual(1100m, account.Total.Value); // 1000 - (-100)
     }
 

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/EditTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/EditTransaction.cs
@@ -98,7 +98,7 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             await _viewModel.EditTransactionCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(-100, account.Transactions[0].Amount.Value);
+            Assert.HasCount(1, account.Transactions);
             Assert.AreEqual(1000, account.Total.Value);
         }
 

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/LoadCategoryNames.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/LoadCategoryNames.cs
@@ -58,7 +58,7 @@ public class LoadCategoryNames
             _updateAccountBalanceDialogService.Object);
 
         // Assert
-        Assert.AreEqual(0, _viewModel.CategoryNames.Count);
+        Assert.IsEmpty(_viewModel.CategoryNames);
     }
 
     [TestMethod]
@@ -101,7 +101,7 @@ public class LoadCategoryNames
             _updateAccountBalanceDialogService.Object);
 
         // Assert
-        Assert.AreEqual(5, _viewModel.CategoryNames.Count);
+        Assert.HasCount(5, _viewModel.CategoryNames);
         Assert.AreEqual("Salary", _viewModel.CategoryNames[0].Item.ToString());
         Assert.AreEqual("Bonus", _viewModel.CategoryNames[1].Item.ToString());
         Assert.AreEqual("Groceries", _viewModel.CategoryNames[2].Item.ToString());
@@ -138,7 +138,7 @@ public class LoadCategoryNames
         _viewModel.OnPageNavigatedTo(); // This calls LoadCategoryNames again
 
         // Assert
-        Assert.AreEqual(2, _viewModel.CategoryNames.Count);
+        Assert.HasCount(2, _viewModel.CategoryNames);
         Assert.AreEqual(1, _viewModel.CategoryNames.Count(x => x.Item.ToString() == "Salary"));
         Assert.AreEqual(1, _viewModel.CategoryNames.Count(x => x.Item.ToString() == "Groceries"));
     }

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
@@ -60,7 +60,7 @@ public class NewAccountTest
         _viewModel.CreateNewAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.Accounts.Count);
+        Assert.HasCount(1, _viewModel.Accounts);
         Assert.AreEqual("Checking", _viewModel.Accounts[0].AccountName);
         Assert.AreEqual(1000m, _viewModel.Accounts[0].Total.Value);
         Assert.IsTrue(_viewModel.TransactionsEnabled);
@@ -86,7 +86,7 @@ public class NewAccountTest
         _viewModel.CreateNewAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.Accounts.Count);
+        Assert.HasCount(1, _viewModel.Accounts);
         Assert.AreEqual(0m, _viewModel.Accounts[0].Total.Value);
     }
 
@@ -106,7 +106,7 @@ public class NewAccountTest
         _viewModel.CreateNewAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(0, _viewModel.Accounts.Count);
+        Assert.IsEmpty(_viewModel.Accounts);
     }
 
     [TestMethod]
@@ -139,7 +139,7 @@ public class NewAccountTest
         _viewModel.CreateNewAccountCommand.Execute(null);
 
         // Assert
-        Assert.AreEqual(2, _viewModel.Accounts.Count);
+        Assert.HasCount(2, _viewModel.Accounts);
         Assert.AreEqual("First Account", _viewModel.Accounts[0].AccountName);
         Assert.AreEqual("Second Account", _viewModel.Accounts[1].AccountName);
         Assert.AreEqual(100m, _viewModel.Accounts[0].Total.Value);

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewTransaction.cs
@@ -56,7 +56,7 @@ public class NewTransactionTests
     public async Task CreateNewTransaction_NoAccountsExist_ReturnsEarly()
     {
         // Arrange
-        Assert.AreEqual(0, _viewModel.Accounts.Count);
+        Assert.IsEmpty(_viewModel.Accounts);
 
         // Act
         await _viewModel.CreateNewTransactionCommand.ExecuteAsync(null);
@@ -111,7 +111,7 @@ public class NewTransactionTests
         await _viewModel.CreateNewTransactionCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(0, account.Transactions.Count);
+        Assert.IsEmpty(account.Transactions);
         Assert.AreEqual(1000, account.Total.Value);
     }
 
@@ -142,7 +142,7 @@ public class NewTransactionTests
         await _viewModel.CreateNewTransactionCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, account.Transactions.Count);
+        Assert.HasCount(1, account.Transactions);
         Assert.AreEqual(500, account.Total.Value); // 1000 - 500
 
         var transaction = account.Transactions[0];
@@ -181,7 +181,7 @@ public class NewTransactionTests
         await _viewModel.CreateNewTransactionCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, account.Transactions.Count);
+        Assert.HasCount(1, account.Transactions);
         Assert.AreEqual(1500, account.Total.Value); // 1000 + 500
 
         var transaction = account.Transactions[0];

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/Transfer.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/Transfer.cs
@@ -83,8 +83,8 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             Assert.AreEqual(600m, account2.Total.Value); // 500 + 100
 
             // Verify transactions created in both accounts
-            Assert.AreEqual(1, account1.Transactions.Count);
-            Assert.AreEqual(1, account2.Transactions.Count);
+            Assert.HasCount(1, account1.Transactions);
+            Assert.HasCount(1, account2.Transactions);
 
             // Verify FROM transaction details
             var fromTransaction = account1.Transactions[0];
@@ -117,8 +117,8 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             // Assert
             Assert.AreEqual(1000m, account1.Total.Value); // Should remain unchanged
             Assert.AreEqual(500m, account2.Total.Value);  // Should remain unchanged
-            Assert.AreEqual(0, account1.Transactions.Count); // No transactions should be created
-            Assert.AreEqual(0, account2.Transactions.Count);
+            Assert.IsEmpty(account1.Transactions); // No transactions should be created
+            Assert.IsEmpty(account2.Transactions);
         }
 
         [TestMethod]
@@ -177,8 +177,8 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             // Assert
             Assert.AreEqual(50m, account1.Total.Value); // Should remain unchanged
             Assert.AreEqual(500m, account2.Total.Value); // Should remain unchanged
-            Assert.AreEqual(0, account1.Transactions.Count); // No transactions should be created
-            Assert.AreEqual(0, account2.Transactions.Count);
+            Assert.IsEmpty(account1.Transactions); // No transactions should be created
+            Assert.IsEmpty(account2.Transactions);
 
             // Verify message box was shown for insufficient funds
             _mockMessageBoxService.Verify(x => x.ShowInfoAsync(It.IsAny<string>(), It.IsAny<string>(),

--- a/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetReportsViewModelTest.cs
@@ -57,8 +57,8 @@ namespace MyMoney.Tests.ViewModelTests
             var viewModel = new BudgetReportsViewModel(mockDatabaseService.Object);
             await viewModel.OnNavigatedToAsync();
 
-            Assert.AreEqual(3, viewModel.IncomeItems.Count);
-            Assert.AreEqual(5, viewModel.ExpenseItems.Count);
+            Assert.HasCount(3, viewModel.IncomeItems);
+            Assert.HasCount(5, viewModel.ExpenseItems);
 
             // Make sure income items are correct
             Assert.AreEqual(330m, viewModel.IncomeItems[0].Actual.Value);

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseGroup.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseGroup.cs
@@ -69,7 +69,7 @@ public class AddExpenseGroupTests
         await viewModel.AddExpenseGroupCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, viewModel.CurrentBudget.BudgetExpenseItems.Count);
+        Assert.HasCount(1, viewModel.CurrentBudget.BudgetExpenseItems);
         Assert.AreEqual("Test Group", viewModel.CurrentBudget.BudgetExpenseItems[0].CategoryName);
     }
 

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddExpenseItem.cs
@@ -94,7 +94,7 @@ public class AddExpenseItemTests
         await _viewModel.AddExpenseItemCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(0, _viewModel.CurrentBudget.BudgetExpenseItems.Count);
+        Assert.IsEmpty(_viewModel.CurrentBudget.BudgetExpenseItems);
     }
 
     [TestMethod]
@@ -120,8 +120,8 @@ public class AddExpenseItemTests
         await _viewModel.AddExpenseItemCommand.ExecuteAsync(budgetExpenseCategory);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetExpenseItems.Count);
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetExpenseItems);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems);
         Assert.AreEqual("Test Category", _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems[0].Category);
         Assert.AreEqual(100m, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems[0].Amount.Value);
     }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddIncomeItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddIncomeItem.cs
@@ -93,7 +93,7 @@ public class AddIncomeItemTests
         await _viewModel.AddIncomeItemCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(0, _viewModel.CurrentBudget.BudgetIncomeItems.Count);
+        Assert.IsEmpty(_viewModel.CurrentBudget.BudgetIncomeItems);
     }
 
     [TestMethod]
@@ -115,7 +115,7 @@ public class AddIncomeItemTests
         await _viewModel.AddIncomeItemCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetIncomeItems.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetIncomeItems);
         Assert.AreEqual("Test Category", _viewModel.CurrentBudget.BudgetIncomeItems[0].Category);
         Assert.AreEqual(100m, _viewModel.CurrentBudget.BudgetIncomeItems[0].Amount.Value);
     }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/AddSavingsCategory.cs
@@ -93,7 +93,7 @@ public class AddSavingsCategoryTests
         await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(0, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.IsEmpty(_viewModel.CurrentBudget.BudgetSavingsCategories);
     }
 
     [TestMethod]
@@ -115,7 +115,7 @@ public class AddSavingsCategoryTests
         await _viewModel.AddSavingsCategoryCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetSavingsCategories);
         Assert.AreEqual("Test Savings", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
         Assert.AreEqual(200m, _viewModel.CurrentBudget.BudgetSavingsCategories[0].BudgetedAmount.Value);
     }
@@ -149,6 +149,6 @@ public class AddSavingsCategoryTests
             It.IsAny<string>(),
             It.IsAny<string>(), It.IsAny<string>()
         ), Times.Once);
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetSavingsCategories);
     }
 }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/CreateNewBudget.cs
@@ -71,11 +71,11 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(1, _viewModel.Budgets.Count);
+            Assert.HasCount(1, _viewModel.Budgets);
             Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
+            Assert.HasCount(0, _viewModel.Budgets[0].BudgetIncomeItems);
+            Assert.HasCount(0, _viewModel.Budgets[0].BudgetExpenseItems);
+            Assert.HasCount(0, _viewModel.Budgets[0].BudgetSavingsCategories);
         }
 
         [TestMethod]
@@ -119,7 +119,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(1, _viewModel.Budgets.Count); // Only the existing budget
+            Assert.HasCount(1, _viewModel.Budgets); // Only the existing budget
             _mockMessageBoxService.Verify(x => x.ShowInfoAsync(
                 "Budget Already Exists",
                 "Cannot create a budget for the selected month because a budget for this month already exists",
@@ -138,7 +138,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(0, _viewModel.Budgets.Count);
+            Assert.HasCount(0, _viewModel.Budgets);
         }
 
         [TestMethod]
@@ -199,19 +199,19 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(2, _viewModel.Budgets.Count);
+            Assert.HasCount(2, _viewModel.Budgets);
             var newBudget = _viewModel.Budgets[1];
             Assert.AreEqual(nextBudgetTitle, newBudget.BudgetTitle);
-            Assert.AreEqual(1, newBudget.BudgetIncomeItems.Count);
+            Assert.HasCount(1, newBudget.BudgetIncomeItems);
             Assert.AreEqual("Income", newBudget.BudgetIncomeItems[0].Category);
-            Assert.AreEqual(1, newBudget.BudgetExpenseItems.Count);
+            Assert.HasCount(1, newBudget.BudgetExpenseItems);
             Assert.AreEqual("Expense", newBudget.BudgetExpenseItems[0].CategoryName);
-            Assert.AreEqual(1, newBudget.BudgetSavingsCategories.Count);
+            Assert.HasCount(1, newBudget.BudgetSavingsCategories);
 
             var newSavings = newBudget.BudgetSavingsCategories[0];
             Assert.AreEqual("Save", newSavings.CategoryName);
             Assert.AreEqual(currentBudget.BudgetSavingsCategories[0].CurrentBalance + currentBudget.BudgetSavingsCategories[0].BudgetedAmount, newSavings.CurrentBalance);
-            Assert.AreEqual(2, newSavings.Transactions.Count); // Old transactions are deleted during copy
+            Assert.HasCount(2, newSavings.Transactions); // Old transactions are deleted during copy
             Assert.AreEqual(newSavings.BudgetedAmount, newSavings.Transactions[1].Amount);
             Assert.AreEqual(newSavings.PlannedTransactionHash, newSavings.Transactions[1].TransactionHash);
         }
@@ -241,11 +241,11 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(1, _viewModel.Budgets.Count);
+            Assert.HasCount(1, _viewModel.Budgets);
             Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
+            Assert.HasCount(0, _viewModel.Budgets[0].BudgetIncomeItems);
+            Assert.IsEmpty(_viewModel.Budgets[0].BudgetExpenseItems);
+            Assert.IsEmpty(_viewModel.Budgets[0].BudgetSavingsCategories);
         }
 
         [TestMethod]
@@ -276,11 +276,11 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
             await _viewModel.CreateNewBudgetCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.AreEqual(1, _viewModel.Budgets.Count);
+            Assert.HasCount(1, _viewModel.Budgets);
             Assert.AreEqual(budgetTitle, _viewModel.Budgets[0].BudgetTitle);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetIncomeItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetExpenseItems.Count);
-            Assert.AreEqual(0, _viewModel.Budgets[0].BudgetSavingsCategories.Count);
+            Assert.IsEmpty(_viewModel.Budgets[0].BudgetIncomeItems);
+            Assert.IsEmpty(_viewModel.Budgets[0].BudgetExpenseItems);
+            Assert.IsEmpty(_viewModel.Budgets[0].BudgetSavingsCategories);
         }
     }
 }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseGroup.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseGroup.cs
@@ -76,7 +76,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
 
             // Assert
             Assert.IsNotNull(_viewModel.CurrentBudget);
-            Assert.IsFalse(_viewModel.CurrentBudget.BudgetExpenseItems.Contains(expenseCategory));
+            Assert.DoesNotContain(expenseCategory, _viewModel.CurrentBudget.BudgetExpenseItems);
         }
 
         [TestMethod]
@@ -133,7 +133,7 @@ namespace MyMoney.Tests.ViewModelTests.BudgetViewModel
 
             // Assert
             Assert.IsNotNull(_viewModel.CurrentBudget);
-            Assert.IsTrue(_viewModel.CurrentBudget.BudgetExpenseItems.Contains(expenseCategory));
+            Assert.Contains(expenseCategory, _viewModel.CurrentBudget.BudgetExpenseItems);
         }
     }
 }

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteExpenseItem.cs
@@ -111,7 +111,7 @@ public class DeleteExpenseItemTests
         await _viewModel.DeleteExpenseItemCommand.ExecuteAsync(new BudgetExpenseCategory());
 
         // Assert
-        Assert.AreEqual(1, budget.BudgetExpenseItems.Count);
+        Assert.HasCount(1, budget.BudgetExpenseItems);
     }
 
     [TestMethod]
@@ -144,8 +144,8 @@ public class DeleteExpenseItemTests
         await _viewModel.DeleteExpenseItemCommand.ExecuteAsync(budget.BudgetExpenseItems[0]);
 
         // Assert
-        Assert.AreEqual(1, budget.BudgetExpenseItems.Count);
-        Assert.AreEqual(2, budget.BudgetExpenseItems[0].SubItems.Count);
+        Assert.HasCount(1, budget.BudgetExpenseItems);
+        Assert.HasCount(2, budget.BudgetExpenseItems[0].SubItems);
         Assert.AreEqual("Category 1", budget.BudgetExpenseItems[0].SubItems[0].Category);
         Assert.AreEqual("Category 3", budget.BudgetExpenseItems[0].SubItems[1].Category);
         Assert.AreEqual(1, budget.BudgetExpenseItems[0].SubItems[0].Id);

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteIncomeItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteIncomeItem.cs
@@ -118,7 +118,7 @@ public class DeleteIncomeItemTests
 
         // Assert
         Assert.IsNotNull(_viewModel.CurrentBudget);
-        Assert.AreEqual(originalCount, _viewModel.CurrentBudget.BudgetIncomeItems.Count);
+        Assert.HasCount(originalCount, _viewModel.CurrentBudget.BudgetIncomeItems);
     }
 
     [TestMethod]
@@ -137,7 +137,7 @@ public class DeleteIncomeItemTests
 
         // Assert
         Assert.IsNotNull(_viewModel.CurrentBudget);
-        Assert.AreEqual(expectedCount, _viewModel.CurrentBudget.BudgetIncomeItems.Count);
+        Assert.HasCount(expectedCount, _viewModel.CurrentBudget.BudgetIncomeItems);
         
         // Verify IDs are reindexed correctly
         for (int i = 0; i < _viewModel.CurrentBudget.BudgetIncomeItems.Count; i++)

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/DeleteSavingsCategory.cs
@@ -91,7 +91,7 @@ public class DeleteSavingsCategoryTests
         await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetSavingsCategories);
     }
 
     [TestMethod]
@@ -112,7 +112,7 @@ public class DeleteSavingsCategoryTests
         await _viewModel.DeleteSavingsCategoryCommand.ExecuteAsync(null);
 
         // Assert
-        Assert.AreEqual(2, _viewModel.CurrentBudget.BudgetSavingsCategories.Count);
+        Assert.HasCount(2, _viewModel.CurrentBudget.BudgetSavingsCategories);
         Assert.AreEqual("A", _viewModel.CurrentBudget.BudgetSavingsCategories[0].CategoryName);
         Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetSavingsCategories[0].Id);
         Assert.AreEqual("C", _viewModel.CurrentBudget.BudgetSavingsCategories[1].CategoryName);

--- a/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseItem.cs
+++ b/MyMoney.Tests/ViewModelTests/BudgetViewModel/EditExpenseItem.cs
@@ -81,7 +81,7 @@ public class EditExpenseItem
         await _viewModel.EditExpenseItemCommand.ExecuteAsync(_viewModel.CurrentBudget.BudgetExpenseItems[0]);
 
         // Assert
-        Assert.AreEqual(1, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems.Count);
+        Assert.HasCount(1, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems);
         Assert.AreEqual("Updated Category", _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems[0].Category);
         Assert.AreEqual(200m, _viewModel.CurrentBudget.BudgetExpenseItems[0].SubItems[0].Amount.Value);
     }


### PR DESCRIPTION
Replace `Assert.AreEqual` calls when checking collection length with `Assert.HasCount` and `Assert.IsEmpty`. Added an assembly attribute to specify that tests should be run in parallel.