### PR TITLE
Don't select all when a textbox gets focus from the mouse

### DIFF
--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
@@ -27,7 +27,6 @@
                 Text="{Binding BudgetCategory}"
                 GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
                 MinWidth="300"
-                GotMouseCapture="TxtCategory_GotMouseCapture"
                 LostKeyboardFocus="TxtCategory_LostKeyboardFocus"
                 LostMouseCapture="TxtCategory_LostMouseCapture"
             />
@@ -40,7 +39,6 @@
             Text="{Binding Path=BudgetAmount, Converter={StaticResource CurrencyConverter}}"
             GotKeyboardFocus="txtAmount_GotKeyboardFocus"
             KeyDown="txtAmount_KeyDown"
-            GotMouseCapture="txtAmount_GotMouseCapture"
         />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
@@ -39,16 +39,6 @@ namespace MyMoney.Views.ContentDialogs
             }
         }
 
-        private void txtAmount_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            txtAmount.SelectAll();
-        }
-
-        private void TxtCategory_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            TxtCategory.SelectAll();
-        }
-
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             if (args.Result != ContentDialogResult.Primary)

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
@@ -27,7 +27,6 @@
             Text="{Binding AccountName}"
             GotFocus="TxtAccountName_GotFocus"
             MinWidth="300"
-            GotMouseCapture="TxtAccountName_GotMouseCapture"
         />
         <Label Margin="0,8,0,4">Starting balance</Label>
         <ui:TextBox
@@ -36,7 +35,6 @@
             Text="{Binding StartingBalance, Converter={StaticResource CurrencyConverter}}"
             GotKeyboardFocus="txtStartingBalance_GotFocus"
             KeyDown="txtStartingBalance_KeyDown"
-            GotMouseCapture="txtStartingBalance_GotMouseCapture"
         />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
@@ -41,16 +41,6 @@ namespace MyMoney.Views.ContentDialogs
             txtStartingBalance.SelectAll();
         }
 
-        private void TxtAccountName_GotMouseCapture(object sender, System.Windows.Input.MouseEventArgs e)
-        {
-            TxtAccountName.SelectAll();
-        }
-
-        private void txtStartingBalance_GotMouseCapture(object sender, System.Windows.Input.MouseEventArgs e)
-        {
-            txtStartingBalance.SelectAll();
-        }
-
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             TxtAccountName.Focus();

--- a/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml
@@ -24,7 +24,6 @@
             HorizontalAlignment="Stretch"
             Text="{Binding GroupName}"
             GotKeyboardFocus="txtGroupName_GotKeyboardFocus"
-            GotMouseCapture="txtGroupName_GotMouseCapture"
             KeyDown="txtGroupName_KeyDown"
         />
     </StackPanel>

--- a/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml.cs
@@ -34,11 +34,6 @@ namespace MyMoney.Views.ContentDialogs
             txtGroupName.SelectAll();
         }
 
-        private void txtGroupName_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            txtGroupName.SelectAll();
-        }
-
         private void txtGroupName_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.Enter)

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -45,7 +45,6 @@
             Margin="0,0,0,16"
             Text="{Binding Path=NewTransactionAmount, Converter={StaticResource CurrencyConverter}}"
             GotKeyboardFocus="txtAmount_GotKeyboardFocus"
-            GotMouseCapture="txtAmount_GotMouseCapture"
         />
         <Grid Margin="0,0,0,16">
             <Grid.ColumnDefinitions>
@@ -123,7 +122,6 @@
             Text="{Binding NewTransactionMemo}"
             KeyDown="TextBox_KeyDown"
             GotKeyboardFocus="txtMemo_GotKeyboardFocus"
-            GotMouseCapture="txtMemo_GotMouseCapture"
         />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -71,17 +71,7 @@ namespace MyMoney.Views.ContentDialogs
             txtAmount.SelectAll();
         }
 
-        private void txtAmount_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            txtAmount.SelectAll();
-        }
-
         private void txtMemo_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-        {
-            txtMemo.SelectAll();
-        }
-
-        private void txtMemo_GotMouseCapture(object sender, MouseEventArgs e)
         {
             txtMemo.SelectAll();
         }

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -45,7 +45,6 @@
                 x:Name="TxtCategory"
                 Text="{Binding Category}"
                 GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
-                GotMouseCapture="TxtCategory_GotMouseCapture"
                 LostFocus="TxtCategory_LostFocus"
             />
         </Border>
@@ -57,7 +56,6 @@
             Text="{Binding Planned, Converter={StaticResource CurrencyConverter}}"
             Margin="1,8,1,0"
             GotKeyboardFocus="TxtPlanned_GotKeyboardFocus"
-            GotMouseCapture="TxtPlanned_GotMouseCapture"
         />
 
         <ui:TextBlock Grid.Row="4" Margin="0,12,0,0">Current balance</ui:TextBlock>
@@ -67,7 +65,6 @@
             Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}}"
             Margin="1,8,1,0"
             GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
-            GotMouseCapture="TxtBalance_GotMouseCapture"
         />
         <ui:TextBlock Margin="24,0,0,0" Grid.Column="1" Visibility="{Binding RecentTransactionsVisibility}"
             >Recent activity</ui:TextBlock

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -24,27 +24,12 @@ namespace MyMoney.Views.ContentDialogs
             TxtCategory.SelectAll();
         }
 
-        private void TxtCategory_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            TxtCategory.SelectAll();
-        }
-
         private void TxtPlanned_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
         {
             TxtPlanned.SelectAll();
         }
 
-        private void TxtPlanned_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            TxtPlanned.SelectAll();
-        }
-
         private void TxtBalance_GotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-        {
-            TxtBalance.SelectAll();
-        }
-
-        private void TxtBalance_GotMouseCapture(object sender, MouseEventArgs e)
         {
             TxtBalance.SelectAll();
         }

--- a/MyMoney/Views/ContentDialogs/TransferDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/TransferDialog.xaml
@@ -51,7 +51,6 @@
             Margin="1,0,1,0"
             GotKeyboardFocus="txtAmount_GotFocus"
             KeyDown="txtAmount_KeyDown"
-            GotMouseCapture="txtAmount_GotMouseCapture"
         />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
@@ -35,11 +35,6 @@ namespace MyMoney.Views.ContentDialogs
             }
         }
 
-        private void txtAmount_GotMouseCapture(object sender, System.Windows.Input.MouseEventArgs e)
-        {
-            txtAmount.SelectAll();
-        }
-
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             if (args.Result != ContentDialogResult.Primary)

--- a/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml
@@ -32,7 +32,6 @@
             Margin="1,0,1,0"
             Text="{Binding Balance, Converter={StaticResource CurrencyConverter}}"
             GotKeyboardFocus="TextBox_GotKeyboardFocus"
-            GotMouseCapture="TextBox_GotMouseCapture"
         />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml.cs
@@ -40,11 +40,6 @@ namespace MyMoney.Views.ContentDialogs
             txtBalance.SelectAll();
         }
 
-        private void TextBox_GotMouseCapture(object sender, MouseEventArgs e)
-        {
-            txtBalance.SelectAll();
-        }
-
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             if (args.Result != ContentDialogResult.Primary)


### PR DESCRIPTION
Removed the `GotMouseCapture` handlers from the textboxes in all the content dialogs.