### PR TITLE
Fix `ContentDialog`-related deprecation warnings

### DIFF
--- a/MyMoney/Abstractions/IContentDialog.cs
+++ b/MyMoney/Abstractions/IContentDialog.cs
@@ -13,7 +13,7 @@ namespace MyMoney.Abstractions
         public string SecondaryButtonText { get; set; }
         public string CloseButtonText { get; set; }
 
-        public ContentPresenter? DialogHost { get; set; }
+        public ContentDialogHost? DialogHostEx { get; set; }
 
         public Task<ContentDialogResult> ShowAsync(CancellationToken cancellationToken = default);
     }

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -299,7 +299,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -328,7 +328,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -439,7 +439,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -544,7 +544,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "Rename";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -567,7 +567,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "Update";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -363,7 +363,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -409,7 +409,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.Title = "New Savings Category";
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -470,7 +470,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "Add";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -512,7 +512,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -561,7 +561,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -651,7 +651,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.Title = "Edit Savings Category";
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -782,7 +782,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "Edit";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -824,7 +824,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
             dialog.DataContext = viewModel;
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 
@@ -926,7 +926,7 @@ namespace MyMoney.ViewModels.Pages
             dialog.DataContext = viewModel;
             dialog.PrimaryButtonText = "OK";
             dialog.CloseButtonText = "Cancel";
-            dialog.DialogHost = _contentDialogService.GetDialogHost();
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
 
             var result = await dialog.ShowAsync();
 

--- a/MyMoney/Views/Windows/MainWindow.xaml
+++ b/MyMoney/Views/Windows/MainWindow.xaml
@@ -79,6 +79,6 @@
             </ui:NavigationView.ContentOverlay>
         </ui:NavigationView>
 
-        <ContentPresenter x:Name="RootContentDialog" Grid.Row="0" />
+        <ui:ContentDialogHost x:Name="RootContentDialog" Grid.Row="0" />
     </Grid>
 </ui:FluentWindow>


### PR DESCRIPTION
Content dialogs now use a `ContentDialogHost` for their `DialogHost` instead of a `ContentPresenter`.