### PR TITLE
Fix budget actual spent stale cache issue

### DIFF
--- a/MyMoney.Core/Database/ReportsCache.cs
+++ b/MyMoney.Core/Database/ReportsCache.cs
@@ -53,7 +53,7 @@ namespace MyMoney.Core.Database
 
         public void InvalidateCacheOnWrite(string collectionName)
         {
-            if (collectionName == "Budgets" || collectionName == "Accounts")
+            if (collectionName == "Budgets" || collectionName == "Accounts" || collectionName == "Transactions")
             {
                 // Invalidate all the budget reports
                 var keysToRemove = _cacheObjects.Keys.Where(key => key.StartsWith("Budget-Report-")).ToList();

--- a/MyMoney/ViewModels/Pages/BudgetViewModel.cs
+++ b/MyMoney/ViewModels/Pages/BudgetViewModel.cs
@@ -110,6 +110,7 @@ namespace MyMoney.ViewModels.Pages
             }
 
             UpdateBudgetTotals(false);
+            await AddActualSpentToCurrentBudget();
 
             // Fire property changed so that colors update if the theme was changed
             OnPropertyChanged(nameof(LeftToBudget));


### PR DESCRIPTION
Fixes #339 

Invalidates the budget report cache when the transactions collection is updated, and reloads actual spent info when the budget page is reloaded.