### PR TITLE
Redesign accounts page

### DIFF
--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/RenameAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/RenameAccount.cs
@@ -61,7 +61,7 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             _contentDialogFactory.Setup(x => x.Create<RenameAccountDialog>()).Returns(fake.Object);
 
             // Act
-            await viewModel.RenameAccountCommand.ExecuteAsync(null);
+            await viewModel.RenameAccountCommand.ExecuteAsync(account);
 
             // Assert
             Assert.AreEqual("New Name", viewModel.Accounts[0].AccountName);
@@ -97,7 +97,7 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             _contentDialogFactory.Setup(x => x.Create<RenameAccountDialog>()).Returns(fake.Object);
 
             // Act
-            await viewModel.RenameAccountCommand.ExecuteAsync(null);
+            await viewModel.RenameAccountCommand.ExecuteAsync(account);
 
             // Assert
             Assert.AreEqual("Original Name", viewModel.Accounts[0].AccountName);

--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -458,11 +458,6 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Microsoft.Xaml.Behaviors.Wpf": {
-        "type": "Transitive",
-        "resolved": "1.1.142",
-        "contentHash": "c47wA/8GHiQ9w+O6+mdqrZhZrxHogx2/fSZyRKL9tz0k+ypoTiwOx6fID0X3jr5LnCazJbCk7KiAcL0zVnNgNA=="
-      },
       "MSTest.Analyzers": {
         "type": "Transitive",
         "resolved": "4.2.1",
@@ -540,16 +535,16 @@
       },
       "WPF-UI": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "cLJCqIYGtbSU8da9UnPV83SU5XttiM+BEZWW/jLSLjjmBvK2s54oDcO2wP36GEVgiXu5/QXJHlgXk0f14Cvw3g==",
+        "resolved": "4.2.1",
+        "contentHash": "SgfFIzYtZWVsffgVXAy7QP8fSoBM6y33d5xUgDZGYGbNeIMEu49ZWJVG3rTWYO3Y+OxWWMrhIa+ER//OOi9t3Q==",
         "dependencies": {
-          "WPF-UI.Abstractions": "4.2.0"
+          "WPF-UI.Abstractions": "4.2.1"
         }
       },
       "WPF-UI.Abstractions": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "N4/ODw2F7yniiaEO6aEaxFC8aMJDJTGoeNNv3LLXFJs+qY2Flu9fMqFrRfcCFTk4ZKg1+guUB6Y0QKi6AGt88w=="
+        "resolved": "4.2.1",
+        "contentHash": "x4RVqFxRH0/KX4VvABWWCjtKu7+lHQC2kGtV/W41BwHMLg4hdA10pUzxJV2L2AouqFewUvKSKCFugDQchf+zAw=="
       },
       "mymoney": {
         "type": "Project",
@@ -558,9 +553,8 @@
           "LiteDB": "[5.0.21, )",
           "LiveChartsCore.SkiaSharpView.WPF": "[2.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.5, )",
-          "Microsoft.Xaml.Behaviors.Wpf": "[1.1.142, )",
           "MyMoney.Core": "[1.0.0, )",
-          "WPF-UI": "[4.2.0, )",
+          "WPF-UI": "[4.2.1, )",
           "gong-wpf-dragdrop": "[4.0.0, )"
         }
       },

--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -458,6 +458,11 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
+      "Microsoft.Xaml.Behaviors.Wpf": {
+        "type": "Transitive",
+        "resolved": "1.1.142",
+        "contentHash": "c47wA/8GHiQ9w+O6+mdqrZhZrxHogx2/fSZyRKL9tz0k+ypoTiwOx6fID0X3jr5LnCazJbCk7KiAcL0zVnNgNA=="
+      },
       "MSTest.Analyzers": {
         "type": "Transitive",
         "resolved": "4.2.1",
@@ -553,6 +558,7 @@
           "LiteDB": "[5.0.21, )",
           "LiveChartsCore.SkiaSharpView.WPF": "[2.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.5, )",
+          "Microsoft.Xaml.Behaviors.Wpf": "[1.1.142, )",
           "MyMoney.Core": "[1.0.0, )",
           "WPF-UI": "[4.2.0, )",
           "gong-wpf-dragdrop": "[4.0.0, )"

--- a/MyMoney/Behaviors/DeleteKeyBehavior.cs
+++ b/MyMoney/Behaviors/DeleteKeyBehavior.cs
@@ -1,0 +1,43 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace MyMoney.Behaviors
+{
+    public static class DeleteKeyBehavior
+    {
+        public static readonly DependencyProperty CommandProperty =
+            DependencyProperty.RegisterAttached(
+                "Command",
+                typeof(ICommand),
+                typeof(DeleteKeyBehavior),
+                new PropertyMetadata(null, OnCommandChanged));
+
+        public static ICommand GetCommand(DependencyObject obj) =>
+            (ICommand)obj.GetValue(CommandProperty);
+
+        public static void SetCommand(DependencyObject obj, ICommand value) =>
+            obj.SetValue(CommandProperty, value);
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is Control control)
+            {
+                control.KeyDown -= OnKeyDown;
+                if (e.NewValue is not null)
+                    control.KeyDown += OnKeyDown;
+            }
+        }
+
+        private static void OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Delete)
+            {
+                var control = (Control)sender;
+                var command = GetCommand(control);
+                if (command?.CanExecute(control.DataContext) == true)
+                    command.Execute(control.DataContext);
+            }
+        }
+    }
+}
+

--- a/MyMoney/Behaviors/DoubleClickBehavior.cs
+++ b/MyMoney/Behaviors/DoubleClickBehavior.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace MyMoney.Behaviors
+{
+    public static class DoubleClickBehavior
+    {
+        public static readonly DependencyProperty CommandProperty =
+            DependencyProperty.RegisterAttached(
+                "Command",
+                typeof(ICommand),
+                typeof(DoubleClickBehavior),
+                new PropertyMetadata(null, OnCommandChanged));
+
+        public static ICommand GetCommand(DependencyObject obj) =>
+            (ICommand)obj.GetValue(CommandProperty);
+
+        public static void SetCommand(DependencyObject obj, ICommand value) =>
+            obj.SetValue(CommandProperty, value);
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is Control control)
+            {
+                control.MouseDoubleClick -= OnMouseDoubleClick;
+                if (e.NewValue is not null)
+                    control.MouseDoubleClick += OnMouseDoubleClick;
+            }
+        }
+
+        private static void OnMouseDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            var control = (Control)sender;
+            var command = GetCommand(control);
+            if (command?.CanExecute(control.DataContext) == true)
+                command.Execute(control.DataContext);
+        }
+    }
+}

--- a/MyMoney/Converters/WidthThresholdToGridViewColumnWidthConverter.cs
+++ b/MyMoney/Converters/WidthThresholdToGridViewColumnWidthConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace MyMoney.Converters
+{
+    public class WidthThresholdToGridViewColumnWidthConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is not double currentWidth)
+            {
+                return double.NaN;
+            }
+
+            // GridViewColumn uses NaN as "Auto".
+            return currentWidth < 600 ? 0d : double.NaN;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/MyMoney/MyMoney.csproj
+++ b/MyMoney/MyMoney.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
         <PackageReference Include="LiteDB" Version="5.0.21" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.0" />
-        <PackageReference Include="WPF-UI" Version="4.2.0" />
+        <PackageReference Include="WPF-UI" Version="4.2.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     </ItemGroup>

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -604,12 +604,11 @@ namespace MyMoney.ViewModels.Pages
         }
 
         [RelayCommand]
-        private async Task RenameAccount()
+        private async Task RenameAccount(Account? account)
         {
-            if (SelectedAccountIndex < 0)
-                return;
+            if (account == null) return;
 
-            var viewModel = new RenameAccountViewModel { NewName = Accounts[SelectedAccountIndex].AccountName };
+            var viewModel = new RenameAccountViewModel { NewName = account.AccountName };
 
             var dialog = _contentDialogFactory.Create<RenameAccountDialog>();
             dialog.PrimaryButtonText = "Rename";
@@ -621,7 +620,7 @@ namespace MyMoney.ViewModels.Pages
 
             if (result == ContentDialogResult.Primary)
             {
-                Accounts[SelectedAccountIndex].AccountName = viewModel.NewName;
+                account.AccountName = viewModel.NewName;
                 SaveAccountsToDatabase();
             }
         }

--- a/MyMoney/Views/Controls/MoreButton.xaml
+++ b/MyMoney/Views/Controls/MoreButton.xaml
@@ -1,0 +1,39 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ControlTemplate x:Key="MoreButtonTemplate" TargetType="Button">
+        <Border
+            Background="{TemplateBinding Background}"
+            BorderBrush="{TemplateBinding BorderBrush}"
+            BorderThickness="{TemplateBinding BorderThickness}"
+            CornerRadius="4"
+            Padding="{TemplateBinding Padding}">
+            <ContentPresenter
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center" />
+        </Border>
+    </ControlTemplate>
+
+    <Style x:Key="MoreButtonStyle" TargetType="Button">
+        <Setter Property="Visibility" Value="Hidden" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="4,2" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Template" Value="{StaticResource MoreButtonTemplate}" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=ListViewItem}}" Value="True">
+                <Setter Property="Visibility" Value="Visible" />
+            </DataTrigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ControlFillColorDefaultBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+            </Trigger>
+            <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="{DynamicResource ControlFillColorSecondaryBrush}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource CardStrokeColorDefaultBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -20,7 +20,7 @@
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Loaded="Page_Loaded"
-    SizeChanged="MainWindow_SizeChanged"
+    ScrollViewer.CanContentScroll="False"
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
@@ -30,13 +30,23 @@
                 <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
                 <TextBox HorizontalAlignment="Stretch" />
             </StackPanel>
+
+            <Style
+                x:Key="RightAlignedGridViewColumnHeaderStyle"
+                BasedOn="{StaticResource UiGridViewColumnHeaderStyle}"
+                TargetType="{x:Type GridViewColumnHeader}">
+                <Style.Setters>
+                    <Setter Property="HorizontalContentAlignment" Value="Right" />
+                    <Setter Property="Padding" Value="0,0,8,0" />
+                </Style.Setters>
+            </Style>
         </ResourceDictionary>
     </Page.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition x:Name="Row1" Height="Auto" />
+            <RowDefinition x:Name="Row1" Height="*" />
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
@@ -110,6 +120,7 @@
         <Grid
             x:Name="TransactionsGrid"
             Grid.Row="0"
+            Grid.RowSpan="2"
             Grid.Column="1"
             Margin="12,0,0,24">
             <Grid.RowDefinitions>
@@ -118,12 +129,10 @@
 
             <ui:Card
                 x:Name="TransactionsCard"
-                Grid.Row="1"
                 VerticalAlignment="Stretch"
                 VerticalContentAlignment="Stretch">
                 <ui:ListView
                     x:Name="TransactionsList"
-                    VerticalAlignment="Top"
                     ItemsSource="{Binding ViewModel.SelectedAccountTransactions}"
                     ScrollViewer.PanningDeceleration="0.001"
                     ScrollViewer.PanningMode="VerticalFirst"
@@ -141,77 +150,109 @@
                         </ContextMenu>
                     </ui:ListView.ContextMenu>
 
-                    <ui:ListView.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel Grid.IsSharedSizeScope="True" />
-                        </ItemsPanelTemplate>
-                    </ui:ListView.ItemsPanel>
+                    <ui:ListView.View>
+                        <ui:GridView>
+                            <ui:GridViewColumn Width="60">
+                                <ui:GridViewColumn.Header>
+                                    <ui:SymbolIcon
+                                        Margin="14,0,0,0"
+                                        VerticalAlignment="Center"
+                                        FontSize="20"
+                                        FontWeight="ExtraBold"
+                                        Symbol="CheckmarkCircle24" />
+                                </ui:GridViewColumn.Header>
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                        <CheckBox
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Command="{Binding DataContext.ViewModel.ReconcileTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
+                                            CommandParameter="{Binding}"
+                                            IsChecked="{Binding Reconciled}" />
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
 
-                    <ui:ListView.ItemTemplate>
-                        <DataTemplate DataType="{x:Type models:Transaction}">
-                            <Grid Margin="0,2,0,2">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="gridDateColumn" />
-                                    <ColumnDefinition Width="Auto" SharedSizeGroup="gridReconciledColumn" />
-                                    <ColumnDefinition Width="5*" />
-                                    <ColumnDefinition Width="1*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
+                            <ui:GridViewColumn Width="80">
+                                <ui:GridViewColumn.Header>
+                                    <TextBlock
+                                        Margin="0,0,0,2"
+                                        FontSize="18"
+                                        Text="Date" />
+                                </ui:GridViewColumn.Header>
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                        <TextBlock VerticalAlignment="Center" Text="{Binding Date, StringFormat=' {0:MMM dd}'}" />
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
 
-                                <Controls:MonthDayControl
-                                    Grid.RowSpan="2"
-                                    Margin="16,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Day="{Binding Path=Date.Day}"
-                                    Month="{Binding Path=MonthAbbreviated}" />
+                            <ui:GridViewColumn Width="220">
+                                <ui:GridViewColumn.Header>
+                                    <TextBlock
+                                        Margin="0,0,0,2"
+                                        FontSize="18"
+                                        Text="Payee" />
+                                </ui:GridViewColumn.Header>
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                        <TextBlock VerticalAlignment="Center" Text="{Binding Payee}" />
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
 
-                                <CheckBox
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="1"
-                                    Margin="16,0"
-                                    VerticalAlignment="Center"
-                                    Command="{Binding DataContext.ViewModel.ReconcileTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
-                                    CommandParameter="{Binding}"
-                                    IsChecked="{Binding Reconciled}" />
+                            <ui:GridViewColumn Width="180">
+                                <ui:GridViewColumn.Header>
+                                    <TextBlock
+                                        Margin="0,0,0,2"
+                                        FontSize="18"
+                                        Text="Category" />
+                                </ui:GridViewColumn.Header>
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                        <TextBlock VerticalAlignment="Center" Text="{Binding Category.Name}" />
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
 
-                                <ui:TextBlock
-                                    Grid.Row="0"
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Left"
-                                    FontSize="16"
-                                    Text="{Binding Payee}" />
-                                <ui:TextBlock
-                                    Grid.Row="1"
-                                    Grid.Column="2"
-                                    HorizontalAlignment="Left"
-                                    Text="{Binding Category.Name}" />
+                            <ui:GridViewColumn Width="120" HeaderContainerStyle="{StaticResource RightAlignedGridViewColumnHeaderStyle}">
 
-                                <TextBlock
-                                    Grid.Row="0"
-                                    Grid.RowSpan="2"
-                                    Grid.Column="3"
-                                    Margin="0,0,16,0"
-                                    HorizontalAlignment="Right"
-                                    FontSize="24"
-                                    FontWeight="SemiBold"
-                                    Text="{Binding AmountFormatted}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="TextBlock">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter}}" Value="True">
-                                                    <Setter Property="Foreground" Value="{StaticResource PositiveForegroundColorBrush}" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
-                            </Grid>
-                        </DataTemplate>
-                    </ui:ListView.ItemTemplate>
+                                <ui:GridViewColumn.Header>
+                                    <TextBlock
+                                        Margin="0,0,0,2"
+                                        FontSize="18"
+                                        Text="Amount" />
+                                </ui:GridViewColumn.Header>
+
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                        <TextBlock
+                                            VerticalAlignment="Center"
+                                            FontSize="18"
+                                            FontWeight="SemiBold"
+                                            Text="{Binding AmountFormatted}"
+                                            TextAlignment="Right">
+                                            <TextBlock.Style>
+                                                <Style TargetType="TextBlock">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter}}" Value="True">
+                                                            <Setter Property="Foreground" Value="{StaticResource PositiveForegroundColorBrush}" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </TextBlock.Style>
+                                        </TextBlock>
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
+                        </ui:GridView>
+                    </ui:ListView.View>
+
+                    <ListView.ItemContainerStyle>
+                        <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="ui:ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
                 </ui:ListView>
             </ui:Card>
         </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -1,4 +1,4 @@
-<Page
+﻿<Page
     x:Class="MyMoney.Views.Pages.AccountsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -24,8 +24,13 @@
     mc:Ignorable="d">
     <Page.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Views/Controls/MoreButton.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
             <converters:CurrencyConverter x:Key="CurrencyConverter" />
             <converters:StartsWithPlusConverter x:Key="StartsWithPlusConverter" />
+
             <StackPanel x:Key="RenameDialogContent">
                 <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
                 <TextBox HorizontalAlignment="Stretch" />
@@ -95,38 +100,57 @@
                 </Grid>
 
                 <ui:ListView
+                    x:Name="AccountsList"
                     Grid.Row="1"
                     ItemsSource="{Binding ViewModel.Accounts}"
                     SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
                     SelectedItem="{Binding ViewModel.SelectedAccount}"
-                    SelectionChanged="AccountsList_SelectionChanged">
+                    SelectionChanged="AccountsList_SelectionChanged"
+                    Tag="{Binding DataContext, RelativeSource={RelativeSource Self}}">
+
+                    <ui:ListView.Resources>
+                        <ContextMenu x:Key="AccountItemContextMenu">
+                            <MenuItem
+                                Command="{Binding DataContext.ViewModel.RenameAccountCommand, Source={x:Reference AccountsList}}"
+                                CommandParameter="{Binding}"
+                                Header="Rename" />
+                            <MenuItem Command="{Binding DataContext.ViewModel.UpdateAccountBalanceCommand, Source={x:Reference AccountsList}}"
+                                      Header="Update balance" />
+                            <MenuItem Command="{Binding DataContext.ViewModel.DeleteAccountCommand, Source={x:Reference AccountsList}}"
+                                      Header="Delete account" />
+                        </ContextMenu>
+                    </ui:ListView.Resources>
+                    
                     <ui:ListView.ItemTemplate>
                         <DataTemplate>
                             <Grid>
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="1*" />
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Margin="4" Text="{Binding AccountName}" />
                                 <ui:TextBlock
                                     Grid.Column="1"
-                                    Margin="4,4,12,4"
+                                    Margin="4"
                                     Text="{Binding Total}"
                                     Typography.NumeralAlignment="Tabular" />
+                                <Button
+                                    Grid.Column="2"
+                                    Style="{StaticResource MoreButtonStyle}"
+                                    Click="MoreButton_Click"
+                                    VerticalAlignment="Center">
+                                    <ui:SymbolIcon Symbol="MoreVertical24" FontSize="18"/>
+                                </Button>
                             </Grid>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>
 
-                    <ui:ListView.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem
-                                Command="{Binding ViewModel.RenameAccountCommand}"
-                                CommandParameter="{StaticResource RenameDialogContent}"
-                                Header="Rename" />
-                            <MenuItem Command="{Binding ViewModel.UpdateAccountBalanceCommand}" Header="Update balance" />
-                            <MenuItem Command="{Binding ViewModel.DeleteAccountCommand}" Header="Delete account" />
-                        </ContextMenu>
-                    </ui:ListView.ContextMenu>
+                    <ui:ListView.ItemContainerStyle>
+                        <Style TargetType="ui:ListViewItem" BasedOn="{StaticResource ListViewItemStyle}">
+                            <Setter Property="ContextMenu" Value="{StaticResource AccountItemContextMenu}" />
+                        </Style>
+                    </ui:ListView.ItemContainerStyle>
                 </ui:ListView>
             </Grid>
         </ui:Card>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -144,7 +144,8 @@
                     Tag="{Binding}"
                     VirtualizingPanel.IsVirtualizing="True"
                     VirtualizingPanel.ScrollUnit="Pixel"
-                    VirtualizingPanel.VirtualizationMode="Recycling">
+                    VirtualizingPanel.VirtualizationMode="Recycling"
+                    AlternationCount="2">
                     <ui:ListView.ContextMenu>
                         <ContextMenu>
                             <MenuItem Command="{Binding ViewModel.EditTransactionCommand}" Header="Edit" />
@@ -261,7 +262,8 @@
                                             FontSize="18"
                                             FontWeight="SemiBold"
                                             Text="{Binding AmountFormatted}"
-                                            TextAlignment="Right">
+                                            TextAlignment="Right"
+                                            Typography.NumeralAlignment="Tabular">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Style.Triggers>
@@ -281,6 +283,12 @@
                     <ListView.ItemContainerStyle>
                         <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="ui:ListViewItem">
                             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Padding" Value="2"/>
+                            <Style.Triggers>
+                                <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                                    <Setter Property="Background" Value="{DynamicResource ControlAltFillColorTertiaryBrush}"/>
+                                </Trigger>
+                            </Style.Triggers>
                         </Style>
                     </ListView.ItemContainerStyle>
                 </ui:ListView>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -6,10 +6,10 @@
     xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
-    xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:local="clr-namespace:MyMoney.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:MyMoney.Core.Models;assembly=MyMoney.Core"
+    xmlns:behaviors="clr-namespace:MyMoney.Behaviors"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="Accounts"
     d:DataContext="{d:DesignInstance {x:Type local:AccountsPage},
@@ -343,6 +343,9 @@
                             <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="ui:ListViewItem">
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="Padding" Value="2" />
+
+                                <Setter Property="behaviors:DoubleClickBehavior.Command" Value="{Binding DataContext.ViewModel.EditTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}" />
+
                                 <Style.Triggers>
                                     <Trigger Property="ItemsControl.AlternationIndex" Value="1">
                                         <Setter Property="Background" Value="{DynamicResource ControlAltFillColorTertiaryBrush}" />

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -38,6 +38,7 @@
                 <Style.Setters>
                     <Setter Property="HorizontalContentAlignment" Value="Right" />
                     <Setter Property="Padding" Value="0,0,8,0" />
+                    <Setter Property="FontWeight" Value="SemiBold" />
                 </Style.Setters>
             </Style>
         </ResourceDictionary>
@@ -179,6 +180,7 @@
                                     <TextBlock
                                         Margin="0,0,0,2"
                                         FontSize="18"
+                                        FontWeight="SemiBold"
                                         Text="Date" />
                                 </ui:GridViewColumn.Header>
                                 <ui:GridViewColumn.CellTemplate>
@@ -188,11 +190,12 @@
                                 </ui:GridViewColumn.CellTemplate>
                             </ui:GridViewColumn>
 
-                            <ui:GridViewColumn Width="220">
+                            <ui:GridViewColumn Width="250">
                                 <ui:GridViewColumn.Header>
                                     <TextBlock
                                         Margin="0,0,0,2"
                                         FontSize="18"
+                                        FontWeight="SemiBold"
                                         Text="Payee" />
                                 </ui:GridViewColumn.Header>
                                 <ui:GridViewColumn.CellTemplate>
@@ -202,11 +205,12 @@
                                 </ui:GridViewColumn.CellTemplate>
                             </ui:GridViewColumn>
 
-                            <ui:GridViewColumn Width="180">
+                            <ui:GridViewColumn Width="Auto">
                                 <ui:GridViewColumn.Header>
                                     <TextBlock
                                         Margin="0,0,0,2"
                                         FontSize="18"
+                                        FontWeight="SemiBold"
                                         Text="Category" />
                                 </ui:GridViewColumn.Header>
                                 <ui:GridViewColumn.CellTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -226,6 +226,20 @@
                                                 VerticalAlignment="Center"
                                                 FontSize="12"
                                                 Text="{Binding Category.Name}" />
+
+                                            <Border.Style>
+                                                <Style TargetType="Border">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding Category.Name}" Value="">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                        <DataTrigger Binding="{Binding Category.Name}" Value="{x:Null}">
+                                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </Border.Style>
                                         </Border>
                                     </DataTemplate>
                                 </ui:GridViewColumn.CellTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -58,12 +58,44 @@
         <ui:Card
             x:Name="AccountsCard"
             Grid.Row="0"
+            Grid.RowSpan="2"
             Grid.Column="0"
             Margin="0,0,12,24"
-            VerticalAlignment="Top">
-            <StackPanel Grid.Column="0">
+            VerticalAlignment="Stretch"
+            VerticalContentAlignment="Stretch">
+            <Grid Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Grid Margin="0,0,0,12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock FontTypography="Subtitle" Text="Accounts" />
+                    <ui:SplitButton
+                        x:Name="NewAccountButton"
+                        Grid.Column="1"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Command="{Binding ViewModel.CreateNewAccountCommand}"
+                        Tag="{Binding ViewModel}">
+                        <StackPanel Orientation="Horizontal">
+                            <ui:SymbolIcon VerticalAlignment="Center" Symbol="Add24" />
+                            <TextBlock Margin="4,0,0,0" VerticalAlignment="Center">New</TextBlock>
+                        </StackPanel>
+
+                        <ui:SplitButton.Flyout>
+                            <ContextMenu>
+                                <ui:MenuItem Command="{Binding ViewModel.TransferBetweenAccountsCommand}" Header="Transfer" />
+                            </ContextMenu>
+                        </ui:SplitButton.Flyout>
+                    </ui:SplitButton>
+                </Grid>
+
                 <ui:ListView
-                    MaxHeight="200"
+                    Grid.Row="1"
                     ItemsSource="{Binding ViewModel.Accounts}"
                     SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
                     SelectedItem="{Binding ViewModel.SelectedAccount}"
@@ -78,8 +110,9 @@
                                 <ui:TextBlock Margin="4" Text="{Binding AccountName}" />
                                 <ui:TextBlock
                                     Grid.Column="1"
-                                    Margin="4"
-                                    Text="{Binding Total}" />
+                                    Margin="4,4,12,4"
+                                    Text="{Binding Total}"
+                                    Typography.NumeralAlignment="Tabular" />
                             </Grid>
                         </DataTemplate>
                     </ui:ListView.ItemTemplate>
@@ -95,27 +128,7 @@
                         </ContextMenu>
                     </ui:ListView.ContextMenu>
                 </ui:ListView>
-                <ui:Button
-                    Margin="0,12,0,8"
-                    HorizontalAlignment="Stretch"
-                    Appearance="Primary"
-                    Command="{Binding ViewModel.CreateNewTransactionCommand}"
-                    IsEnabled="{Binding ViewModel.TransactionsEnabled}">
-                    New transaction
-                </ui:Button>
-                <ui:Button
-                    Margin="0,0,0,8"
-                    HorizontalAlignment="Stretch"
-                    Command="{Binding ViewModel.CreateNewAccountCommand}">
-                    New account
-                </ui:Button>
-                <ui:Button
-                    HorizontalAlignment="Stretch"
-                    Command="{Binding ViewModel.TransferBetweenAccountsCommand}"
-                    IsEnabled="{Binding ViewModel.TransactionsEnabled}">
-                    Transfer
-                </ui:Button>
-            </StackPanel>
+            </Grid>
         </ui:Card>
 
         <Grid
@@ -132,166 +145,214 @@
                 x:Name="TransactionsCard"
                 VerticalAlignment="Stretch"
                 VerticalContentAlignment="Stretch">
-                <ui:ListView
-                    x:Name="TransactionsList"
-                    ItemsSource="{Binding ViewModel.SelectedAccountTransactions}"
-                    ScrollViewer.PanningDeceleration="0.001"
-                    ScrollViewer.PanningMode="VerticalFirst"
-                    ScrollViewer.PanningRatio="1.5"
-                    ScrollViewer.ScrollChanged="TransactionsList_ScrollChanged"
-                    SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
-                    SelectedItem="{Binding ViewModel.SelectedTransaction}"
-                    Tag="{Binding}"
-                    VirtualizingPanel.IsVirtualizing="True"
-                    VirtualizingPanel.ScrollUnit="Pixel"
-                    VirtualizingPanel.VirtualizationMode="Recycling"
-                    AlternationCount="2">
-                    <ui:ListView.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Command="{Binding ViewModel.EditTransactionCommand}" Header="Edit" />
-                            <MenuItem Command="{Binding ViewModel.DeleteTransactionCommand}" Header="Delete" />
-                        </ContextMenu>
-                    </ui:ListView.ContextMenu>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
 
-                    <ui:ListView.View>
-                        <ui:GridView>
-                            <ui:GridViewColumn Width="60">
-                                <ui:GridViewColumn.Header>
-                                    <ui:SymbolIcon
-                                        Margin="14,0,0,0"
-                                        VerticalAlignment="Center"
-                                        FontSize="20"
-                                        FontWeight="ExtraBold"
-                                        Symbol="CheckmarkCircle24" />
-                                </ui:GridViewColumn.Header>
-                                <ui:GridViewColumn.CellTemplate>
-                                    <DataTemplate DataType="{x:Type models:Transaction}">
-                                        <CheckBox
-                                            HorizontalAlignment="Center"
+                    <Grid Grid.Row="0" Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBlock FontTypography="Subtitle" Text="Transactions" />
+
+                        <ui:TextBox
+                            Grid.Column="1"
+                            Width="250"
+                            PlaceholderText="Search transactions">
+                            <ui:TextBox.Icon>
+                                <ui:SymbolIcon Symbol="Search24" />
+                            </ui:TextBox.Icon>
+                        </ui:TextBox>
+
+                        <ui:Button
+                            Grid.Column="2"
+                            Margin="8,0"
+                            VerticalAlignment="Stretch"
+                            ToolTip="Export as CSV">
+                            <ui:SymbolIcon Symbol="ArrowExportLtr24" />
+                        </ui:Button>
+
+                        <ui:Button
+                            Grid.Column="3"
+                            VerticalAlignment="Stretch"
+                            Appearance="Primary"
+                            Command="{Binding ViewModel.CreateNewTransactionCommand}"
+                            ToolTip="New transaction">
+                            <StackPanel Orientation="Horizontal">
+                                <ui:SymbolIcon Symbol="Add24" />
+                                <TextBlock Margin="4,0,0,0" Text="New" />
+                            </StackPanel>
+                        </ui:Button>
+                    </Grid>
+
+                    <ui:ListView
+                        x:Name="TransactionsList"
+                        Grid.Row="1"
+                        AlternationCount="2"
+                        ItemsSource="{Binding ViewModel.SelectedAccountTransactions}"
+                        ScrollViewer.PanningDeceleration="0.001"
+                        ScrollViewer.PanningMode="VerticalFirst"
+                        ScrollViewer.PanningRatio="1.5"
+                        ScrollViewer.ScrollChanged="TransactionsList_ScrollChanged"
+                        SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
+                        SelectedItem="{Binding ViewModel.SelectedTransaction}"
+                        Tag="{Binding}"
+                        VirtualizingPanel.IsVirtualizing="True"
+                        VirtualizingPanel.ScrollUnit="Pixel"
+                        VirtualizingPanel.VirtualizationMode="Recycling">
+                        <ui:ListView.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Command="{Binding ViewModel.EditTransactionCommand}" Header="Edit" />
+                                <MenuItem Command="{Binding ViewModel.DeleteTransactionCommand}" Header="Delete" />
+                            </ContextMenu>
+                        </ui:ListView.ContextMenu>
+
+                        <ui:ListView.View>
+                            <ui:GridView>
+                                <ui:GridViewColumn Width="60">
+                                    <ui:GridViewColumn.Header>
+                                        <ui:SymbolIcon
+                                            Margin="14,0,0,0"
                                             VerticalAlignment="Center"
-                                            Command="{Binding Tag.ViewModel.ReconcileTransactionCommand, ElementName=TransactionsList}"
-                                            CommandParameter="{Binding}"
-                                            IsChecked="{Binding Reconciled}" />
-                                    </DataTemplate>
-                                </ui:GridViewColumn.CellTemplate>
-                            </ui:GridViewColumn>
-
-                            <ui:GridViewColumn Width="80">
-                                <ui:GridViewColumn.Header>
-                                    <TextBlock
-                                        Margin="0,0,0,2"
-                                        FontSize="18"
-                                        FontWeight="SemiBold"
-                                        Text="Date" />
-                                </ui:GridViewColumn.Header>
-                                <ui:GridViewColumn.CellTemplate>
-                                    <DataTemplate DataType="{x:Type models:Transaction}">
-                                        <TextBlock VerticalAlignment="Center" Text="{Binding Date, StringFormat=' {0:MMM dd}'}" />
-                                    </DataTemplate>
-                                </ui:GridViewColumn.CellTemplate>
-                            </ui:GridViewColumn>
-
-                            <ui:GridViewColumn Width="250">
-                                <ui:GridViewColumn.Header>
-                                    <TextBlock
-                                        Margin="0,0,0,2"
-                                        FontSize="18"
-                                        FontWeight="SemiBold"
-                                        Text="Payee" />
-                                </ui:GridViewColumn.Header>
-                                <ui:GridViewColumn.CellTemplate>
-                                    <DataTemplate DataType="{x:Type models:Transaction}">
-                                        <TextBlock VerticalAlignment="Center" Text="{Binding Payee}" />
-                                    </DataTemplate>
-                                </ui:GridViewColumn.CellTemplate>
-                            </ui:GridViewColumn>
-
-                            <ui:GridViewColumn Width="Auto">
-                                <ui:GridViewColumn.Header>
-                                    <TextBlock
-                                        Margin="0,0,0,2"
-                                        FontSize="18"
-                                        FontWeight="SemiBold"
-                                        Text="Category" />
-                                </ui:GridViewColumn.Header>
-                                <ui:GridViewColumn.CellTemplate>
-                                    <DataTemplate DataType="{x:Type models:Transaction}">
-                                        <Border
-                                            Padding="4"
-                                            HorizontalAlignment="Left"
-                                            Background="{DynamicResource LayerOnMicaBaseAltFillColorSecondaryBrush}"
-                                            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                            BorderThickness="1"
-                                            CornerRadius="12">
-                                            <TextBlock
+                                            FontSize="20"
+                                            FontWeight="ExtraBold"
+                                            Symbol="CheckmarkCircle24" />
+                                    </ui:GridViewColumn.Header>
+                                    <ui:GridViewColumn.CellTemplate>
+                                        <DataTemplate DataType="{x:Type models:Transaction}">
+                                            <CheckBox
+                                                HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
-                                                FontSize="12"
-                                                Text="{Binding Category.Name}" />
+                                                Command="{Binding Tag.ViewModel.ReconcileTransactionCommand, ElementName=TransactionsList}"
+                                                CommandParameter="{Binding}"
+                                                IsChecked="{Binding Reconciled}" />
+                                        </DataTemplate>
+                                    </ui:GridViewColumn.CellTemplate>
+                                </ui:GridViewColumn>
 
-                                            <Border.Style>
-                                                <Style TargetType="Border">
-                                                    <Setter Property="Visibility" Value="Visible"/>
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Category.Name}" Value="">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                        </DataTrigger>
-                                                        <DataTrigger Binding="{Binding Category.Name}" Value="{x:Null}">
-                                                            <Setter Property="Visibility" Value="Collapsed"/>
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </Border.Style>
-                                        </Border>
-                                    </DataTemplate>
-                                </ui:GridViewColumn.CellTemplate>
-                            </ui:GridViewColumn>
-
-                            <ui:GridViewColumn Width="120" HeaderContainerStyle="{StaticResource RightAlignedGridViewColumnHeaderStyle}">
-
-                                <ui:GridViewColumn.Header>
-                                    <TextBlock
-                                        Margin="0,0,0,2"
-                                        FontSize="18"
-                                        Text="Amount" />
-                                </ui:GridViewColumn.Header>
-
-                                <ui:GridViewColumn.CellTemplate>
-                                    <DataTemplate DataType="{x:Type models:Transaction}">
+                                <ui:GridViewColumn Width="80">
+                                    <ui:GridViewColumn.Header>
                                         <TextBlock
-                                            VerticalAlignment="Center"
+                                            Margin="0,0,0,2"
                                             FontSize="18"
                                             FontWeight="SemiBold"
-                                            Text="{Binding AmountFormatted}"
-                                            TextAlignment="Right"
-                                            Typography.NumeralAlignment="Tabular">
-                                            <TextBlock.Style>
-                                                <Style TargetType="TextBlock">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter}}" Value="True">
-                                                            <Setter Property="Foreground" Value="{StaticResource PositiveForegroundColorBrush}" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </TextBlock.Style>
-                                        </TextBlock>
-                                    </DataTemplate>
-                                </ui:GridViewColumn.CellTemplate>
-                            </ui:GridViewColumn>
-                        </ui:GridView>
-                    </ui:ListView.View>
+                                            Text="Date" />
+                                    </ui:GridViewColumn.Header>
+                                    <ui:GridViewColumn.CellTemplate>
+                                        <DataTemplate DataType="{x:Type models:Transaction}">
+                                            <TextBlock VerticalAlignment="Center" Text="{Binding Date, StringFormat=' {0:MMM dd}'}" />
+                                        </DataTemplate>
+                                    </ui:GridViewColumn.CellTemplate>
+                                </ui:GridViewColumn>
 
-                    <ListView.ItemContainerStyle>
-                        <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="ui:ListViewItem">
-                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            <Setter Property="Padding" Value="2"/>
-                            <Style.Triggers>
-                                <Trigger Property="ItemsControl.AlternationIndex" Value="1">
-                                    <Setter Property="Background" Value="{DynamicResource ControlAltFillColorTertiaryBrush}"/>
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ListView.ItemContainerStyle>
-                </ui:ListView>
+                                <ui:GridViewColumn Width="250">
+                                    <ui:GridViewColumn.Header>
+                                        <TextBlock
+                                            Margin="0,0,0,2"
+                                            FontSize="18"
+                                            FontWeight="SemiBold"
+                                            Text="Payee" />
+                                    </ui:GridViewColumn.Header>
+                                    <ui:GridViewColumn.CellTemplate>
+                                        <DataTemplate DataType="{x:Type models:Transaction}">
+                                            <TextBlock VerticalAlignment="Center" Text="{Binding Payee}" />
+                                        </DataTemplate>
+                                    </ui:GridViewColumn.CellTemplate>
+                                </ui:GridViewColumn>
+
+                                <ui:GridViewColumn Width="Auto">
+                                    <ui:GridViewColumn.Header>
+                                        <TextBlock
+                                            Margin="0,0,0,2"
+                                            FontSize="18"
+                                            FontWeight="SemiBold"
+                                            Text="Category" />
+                                    </ui:GridViewColumn.Header>
+                                    <ui:GridViewColumn.CellTemplate>
+                                        <DataTemplate DataType="{x:Type models:Transaction}">
+                                            <Border
+                                                Padding="4"
+                                                HorizontalAlignment="Left"
+                                                Background="{DynamicResource LayerOnMicaBaseAltFillColorSecondaryBrush}"
+                                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="12">
+                                                <TextBlock
+                                                    VerticalAlignment="Center"
+                                                    FontSize="12"
+                                                    Text="{Binding Category.Name}" />
+
+                                                <Border.Style>
+                                                    <Style TargetType="Border">
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding Category.Name}" Value="">
+                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                            </DataTrigger>
+                                                            <DataTrigger Binding="{Binding Category.Name}" Value="{x:Null}">
+                                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </Border.Style>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ui:GridViewColumn.CellTemplate>
+                                </ui:GridViewColumn>
+
+                                <ui:GridViewColumn Width="120" HeaderContainerStyle="{StaticResource RightAlignedGridViewColumnHeaderStyle}">
+
+                                    <ui:GridViewColumn.Header>
+                                        <TextBlock
+                                            Margin="0,0,0,2"
+                                            FontSize="18"
+                                            Text="Amount" />
+                                    </ui:GridViewColumn.Header>
+
+                                    <ui:GridViewColumn.CellTemplate>
+                                        <DataTemplate DataType="{x:Type models:Transaction}">
+                                            <TextBlock
+                                                VerticalAlignment="Center"
+                                                FontSize="18"
+                                                FontWeight="SemiBold"
+                                                Text="{Binding AmountFormatted}"
+                                                TextAlignment="Right"
+                                                Typography.NumeralAlignment="Tabular">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding AmountFormatted, Converter={StaticResource StartsWithPlusConverter}}" Value="True">
+                                                                <Setter Property="Foreground" Value="{StaticResource PositiveForegroundColorBrush}" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </DataTemplate>
+                                    </ui:GridViewColumn.CellTemplate>
+                                </ui:GridViewColumn>
+                            </ui:GridView>
+                        </ui:ListView.View>
+
+                        <ListView.ItemContainerStyle>
+                            <Style BasedOn="{StaticResource ListViewItemStyle}" TargetType="ui:ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="Padding" Value="2" />
+                                <Style.Triggers>
+                                    <Trigger Property="ItemsControl.AlternationIndex" Value="1">
+                                        <Setter Property="Background" Value="{DynamicResource ControlAltFillColorTertiaryBrush}" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                    </ui:ListView>
+                </Grid>
+
             </ui:Card>
         </Grid>
     </Grid>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -133,6 +133,7 @@
                 VerticalContentAlignment="Stretch">
                 <ui:ListView
                     x:Name="TransactionsList"
+                    Tag="{Binding}"
                     ItemsSource="{Binding ViewModel.SelectedAccountTransactions}"
                     ScrollViewer.PanningDeceleration="0.001"
                     ScrollViewer.PanningMode="VerticalFirst"
@@ -166,7 +167,7 @@
                                         <CheckBox
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
-                                            Command="{Binding DataContext.ViewModel.ReconcileTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
+                                            Command="{Binding Tag.ViewModel.ReconcileTransactionCommand, ElementName=TransactionsList}"
                                             CommandParameter="{Binding}"
                                             IsChecked="{Binding Reconciled}" />
                                     </DataTemplate>

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -1,15 +1,15 @@
-﻿<Page
+<Page
     x:Class="MyMoney.Views.Pages.AccountsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:Controls="clr-namespace:MyMoney.Views.Controls"
+    xmlns:behaviors="clr-namespace:MyMoney.Behaviors"
     xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
     xmlns:local="clr-namespace:MyMoney.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:MyMoney.Core.Models;assembly=MyMoney.Core"
-    xmlns:behaviors="clr-namespace:MyMoney.Behaviors"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="Accounts"
     d:DataContext="{d:DesignInstance {x:Type local:AccountsPage},
@@ -345,6 +345,7 @@
                                 <Setter Property="Padding" Value="2" />
 
                                 <Setter Property="behaviors:DoubleClickBehavior.Command" Value="{Binding DataContext.ViewModel.EditTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}" />
+                                <Setter Property="behaviors:DeleteKeyBehavior.Command" Value="{Binding DataContext.ViewModel.DeleteTransactionCommand, RelativeSource={RelativeSource AncestorType=ui:ListView}}" />
 
                                 <Style.Triggers>
                                     <Trigger Property="ItemsControl.AlternationIndex" Value="1">

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -30,6 +30,7 @@
 
             <converters:CurrencyConverter x:Key="CurrencyConverter" />
             <converters:StartsWithPlusConverter x:Key="StartsWithPlusConverter" />
+            <converters:WidthThresholdToGridViewColumnWidthConverter x:Key="WidthThresholdToGridViewColumnWidthConverter" />
 
             <StackPanel x:Key="RenameDialogContent">
                 <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
@@ -289,7 +290,7 @@
                                     </ui:GridViewColumn.CellTemplate>
                                 </ui:GridViewColumn>
 
-                                <ui:GridViewColumn Width="Auto">
+                                <ui:GridViewColumn Width="{Binding ActualWidth, ElementName=TransactionsList, Converter={StaticResource WidthThresholdToGridViewColumnWidthConverter}}">
                                     <ui:GridViewColumn.Header>
                                         <TextBlock
                                             Margin="0,0,0,2"

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -133,7 +133,6 @@
                 VerticalContentAlignment="Stretch">
                 <ui:ListView
                     x:Name="TransactionsList"
-                    Tag="{Binding}"
                     ItemsSource="{Binding ViewModel.SelectedAccountTransactions}"
                     ScrollViewer.PanningDeceleration="0.001"
                     ScrollViewer.PanningMode="VerticalFirst"
@@ -141,6 +140,7 @@
                     ScrollViewer.ScrollChanged="TransactionsList_ScrollChanged"
                     SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                     SelectedItem="{Binding ViewModel.SelectedTransaction}"
+                    Tag="{Binding}"
                     VirtualizingPanel.IsVirtualizing="True"
                     VirtualizingPanel.ScrollUnit="Pixel"
                     VirtualizingPanel.VirtualizationMode="Recycling">
@@ -211,7 +211,18 @@
                                 </ui:GridViewColumn.Header>
                                 <ui:GridViewColumn.CellTemplate>
                                     <DataTemplate DataType="{x:Type models:Transaction}">
-                                        <TextBlock VerticalAlignment="Center" Text="{Binding Category.Name}" />
+                                        <Border
+                                            Padding="4"
+                                            HorizontalAlignment="Left"
+                                            Background="{DynamicResource LayerOnMicaBaseAltFillColorSecondaryBrush}"
+                                            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="12">
+                                            <TextBlock
+                                                VerticalAlignment="Center"
+                                                FontSize="12"
+                                                Text="{Binding Category.Name}" />
+                                        </Border>
                                     </DataTemplate>
                                 </ui:GridViewColumn.CellTemplate>
                             </ui:GridViewColumn>

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -32,46 +32,11 @@ namespace MyMoney.Views.Pages
 
             _wideTransactionMargin = TransactionsGrid.Margin;
             _wideAccountsMargin = AccountsCard.Margin;
-
-            Application.Current.MainWindow.SizeChanged += MainWindow_SizeChanged;
-        }
-
-        private void MainWindow_SizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            if (e.NewSize.Width < 750)
-            {
-                // stacked
-                Col0.Width = new GridLength(0);
-                Grid.SetColumn(AccountsCard, 1);
-                Grid.SetRow(AccountsCard, 0);
-                Grid.SetRow(TransactionsGrid, 1);
-                TransactionsGrid.Margin = _narrowMargin;
-                AccountsCard.Margin = _narrowMargin;
-            }
-            else
-            {
-                // side‑by‑side: first fixed, second star
-                Col0.Width = new GridLength(275);
-                Grid.SetColumn(AccountsCard, 0);
-                Grid.SetRow(AccountsCard, 0);
-                Grid.SetRow(TransactionsGrid, 0);
-                TransactionsGrid.Margin = _wideTransactionMargin;
-                AccountsCard.Margin = _wideAccountsMargin;
-            }
-
-            UpdateTransactionsMaxHeight();
-        }
-
-        private void UpdateTransactionsMaxHeight()
-        {
-            TransactionsList.MaxHeight = Application.Current.MainWindow.ActualHeight - 220;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)
         {
             ViewModel.OnPageNavigatedTo();
-
-            UpdateTransactionsMaxHeight();
             _isLoaded = true;
         }
 
@@ -85,7 +50,7 @@ namespace MyMoney.Views.Pages
             await ViewModel.SelectedAccountChanged();
         }
 
-        private void ResetScroll(Wpf.Ui.Controls.ListView list)
+        private void ResetScroll(System.Windows.Controls.ListView list)
         {
             var scroll = FindScrollViewer(list);
             scroll?.ScrollToTop();

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Media;
 using MyMoney.ViewModels.Pages;
 using Wpf.Ui;
@@ -68,6 +69,22 @@ namespace MyMoney.Views.Pages
             if (viewer.VerticalOffset + viewer.ViewportHeight >= viewer.ExtentHeight - 200)
             {
                 await ViewModel.LoadTransactions();
+            }
+        }
+
+        private void MoreButton_Click(object sender, RoutedEventArgs e)
+        {
+            var button = (System.Windows.Controls.Button)sender;
+            AccountsList.SelectedItem = button.DataContext;
+
+            // Walk up to the ListViewItem to grab its ContextMenu
+            var listViewItem = ItemsControl.ContainerFromElement(AccountsList, button) as Wpf.Ui.Controls.ListViewItem;
+            if (listViewItem?.ContextMenu is ContextMenu menu)
+            {
+                menu.PlacementTarget = button; // anchor it to the button visually
+                menu.Placement = System.Windows.Controls.Primitives.PlacementMode.Bottom;
+                menu.DataContext = button.DataContext; // ensure bindings in menu items work
+                menu.IsOpen = true;
             }
         }
     }

--- a/MyMoney/Views/Pages/AccountsPage.xaml.cs
+++ b/MyMoney/Views/Pages/AccountsPage.xaml.cs
@@ -14,13 +14,6 @@ namespace MyMoney.Views.Pages
     {
         bool _isLoaded = false;
 
-        // Cache the “wide” padding so we can restore it
-        private Thickness _wideTransactionMargin;
-        private Thickness _wideAccountsMargin;
-
-        // Define the “narrow” padding (no left inset)
-        private readonly Thickness _narrowMargin = new Thickness(0, 0, 0, 24);
-
         public AccountsViewModel ViewModel { get; }
 
         public AccountsPage(AccountsViewModel viewModel)
@@ -29,9 +22,6 @@ namespace MyMoney.Views.Pages
             DataContext = this;
 
             InitializeComponent();
-
-            _wideTransactionMargin = TransactionsGrid.Margin;
-            _wideAccountsMargin = AccountsCard.Margin;
         }
 
         private void Page_Loaded(object sender, RoutedEventArgs e)

--- a/MyMoney/packages.lock.json
+++ b/MyMoney/packages.lock.json
@@ -63,11 +63,11 @@
       },
       "WPF-UI": {
         "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "cLJCqIYGtbSU8da9UnPV83SU5XttiM+BEZWW/jLSLjjmBvK2s54oDcO2wP36GEVgiXu5/QXJHlgXk0f14Cvw3g==",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "SgfFIzYtZWVsffgVXAy7QP8fSoBM6y33d5xUgDZGYGbNeIMEu49ZWJVG3rTWYO3Y+OxWWMrhIa+ER//OOi9t3Q==",
         "dependencies": {
-          "WPF-UI.Abstractions": "4.2.0"
+          "WPF-UI.Abstractions": "4.2.1"
         }
       },
       "HarfBuzzSharp": {
@@ -415,8 +415,8 @@
       },
       "WPF-UI.Abstractions": {
         "type": "Transitive",
-        "resolved": "4.2.0",
-        "contentHash": "N4/ODw2F7yniiaEO6aEaxFC8aMJDJTGoeNNv3LLXFJs+qY2Flu9fMqFrRfcCFTk4ZKg1+guUB6Y0QKi6AGt88w=="
+        "resolved": "4.2.1",
+        "contentHash": "x4RVqFxRH0/KX4VvABWWCjtKu7+lHQC2kGtV/W41BwHMLg4hdA10pUzxJV2L2AouqFewUvKSKCFugDQchf+zAw=="
       },
       "mymoney.core": {
         "type": "Project",


### PR DESCRIPTION
New look for accounts page. The accounts list has been made full height, and the new account button has been moved to the top of the list. It is now a split button, with transfer being the action in the dropdown. The new transaction button has been moved to the top of the transactions list. The transactions list has been redesigned, with it now being a `GridView` with columns.

A search box and an export button were added to the top of the transactions list beside the new transaction button, but these actions are not yet implemented. They will be finished in another PR.

Closes #335
