### PR TITLE
Add transaction search

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet test *)"
+    ]
+  }
+}

--- a/MyMoney.Core/Database/DatabaseManager.cs
+++ b/MyMoney.Core/Database/DatabaseManager.cs
@@ -212,7 +212,6 @@ namespace MyMoney.Core.Database
                          t.Category.Name.ToLower().Contains(lowerQuery)) ||
                         (t.Memo != null && t.Memo.ToLower().Contains(lowerQuery)))
                     .ToList();
-                await Task.CompletedTask;
             });
 
             return results;

--- a/MyMoney.Core/Database/DatabaseManager.cs
+++ b/MyMoney.Core/Database/DatabaseManager.cs
@@ -19,6 +19,12 @@ namespace MyMoney.Core.Database
         public bool Delete<T>(string collectionName, BsonValue id);
         public int DeleteMany<T>(string collectionName, System.Linq.Expressions.Expression<Func<T, bool>> predicate);
         public Task QueryAsync<T>(string collectionName, Func<ILiteQueryable<T>, Task> action);
+
+        /// <summary>
+        /// Returns all transactions for the given account whose Payee or Category.Name
+        /// contains <paramref name="query"/> (case-insensitive).
+        /// </summary>
+        Task<List<Core.Models.Transaction>> SearchTransactionsAsync(int accountId, string query);
     }
 
     public class DatabaseManager : IDatabaseManager, IDisposable
@@ -188,6 +194,27 @@ namespace MyMoney.Core.Database
         {
             var collection = _db.GetCollection<T>(collectionName);
             await action(collection.Query());
+        }
+
+        public async Task<List<Core.Models.Transaction>> SearchTransactionsAsync(int accountId, string query)
+        {
+            var results = new List<Core.Models.Transaction>();
+            var lowerQuery = query.ToLower();
+
+            await QueryAsync<Core.Models.Transaction>("Transactions", async q =>
+            {
+                results = q
+                    .Where(t => t.AccountId == accountId)
+                    .ToList()
+                    .Where(t =>
+                        (t.Payee != null && t.Payee.ToLower().Contains(lowerQuery)) ||
+                        (t.Category != null && t.Category.Name != null &&
+                         t.Category.Name.ToLower().Contains(lowerQuery)))
+                    .ToList();
+                await Task.CompletedTask;
+            });
+
+            return results;
         }
 
         public void Dispose()

--- a/MyMoney.Core/Database/DatabaseManager.cs
+++ b/MyMoney.Core/Database/DatabaseManager.cs
@@ -21,7 +21,7 @@ namespace MyMoney.Core.Database
         public Task QueryAsync<T>(string collectionName, Func<ILiteQueryable<T>, Task> action);
 
         /// <summary>
-        /// Returns all transactions for the given account whose Payee or Category.Name
+        /// Returns all transactions for the given account whose Payee, Category.Name, or Memo
         /// contains <paramref name="query"/> (case-insensitive).
         /// </summary>
         Task<List<Core.Models.Transaction>> SearchTransactionsAsync(int accountId, string query);
@@ -209,7 +209,8 @@ namespace MyMoney.Core.Database
                     .Where(t =>
                         (t.Payee != null && t.Payee.ToLower().Contains(lowerQuery)) ||
                         (t.Category != null && t.Category.Name != null &&
-                         t.Category.Name.ToLower().Contains(lowerQuery)))
+                         t.Category.Name.ToLower().Contains(lowerQuery)) ||
+                        (t.Memo != null && t.Memo.ToLower().Contains(lowerQuery)))
                     .ToList();
                 await Task.CompletedTask;
             });

--- a/MyMoney.Tests/DatabaseTests/SearchTransactionsTests.cs
+++ b/MyMoney.Tests/DatabaseTests/SearchTransactionsTests.cs
@@ -8,9 +8,9 @@ public class SearchTransactionsTests
 {
     private DatabaseManager _db = null!;
 
-    private static Transaction MakeTransaction(int accountId, string payee, string categoryName, int id = 0)
+    private static Transaction MakeTransaction(int accountId, string payee, string categoryName, int id = 0, string memo = "")
     {
-        var t = new Transaction(DateTime.Today, payee, new Category { Name = categoryName }, new Currency(10m), "")
+        var t = new Transaction(DateTime.Today, payee, new Category { Name = categoryName }, new Currency(10m), memo)
         {
             AccountId = accountId,
             Id = id
@@ -76,6 +76,23 @@ public class SearchTransactionsTests
         // Assert
         Assert.HasCount(1, results);
         Assert.AreEqual("Groceries", results[0].Category.Name);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_MatchesOnMemo_CaseInsensitive()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Store A", categoryName: "Shopping", id: 1, memo: "Monthly invoice #42");
+        var t2 = MakeTransaction(accountId: 1, payee: "Store B", categoryName: "Shopping", id: 2, memo: "Cash back");
+        _db.Insert("Transactions", t1);
+        _db.Insert("Transactions", t2);
+
+        // Act — uppercase query on memo only
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "INVOICE");
+
+        // Assert
+        Assert.HasCount(1, results);
+        Assert.AreEqual("Monthly invoice #42", results[0].Memo);
     }
 
     [TestMethod]

--- a/MyMoney.Tests/DatabaseTests/SearchTransactionsTests.cs
+++ b/MyMoney.Tests/DatabaseTests/SearchTransactionsTests.cs
@@ -1,0 +1,123 @@
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Tests.DatabaseTests;
+
+[TestClass]
+public class SearchTransactionsTests
+{
+    private DatabaseManager _db = null!;
+
+    private static Transaction MakeTransaction(int accountId, string payee, string categoryName, int id = 0)
+    {
+        var t = new Transaction(DateTime.Today, payee, new Category { Name = categoryName }, new Currency(10m), "")
+        {
+            AccountId = accountId,
+            Id = id
+        };
+        return t;
+    }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _db = new DatabaseManager(new System.IO.MemoryStream());
+    }
+
+    [TestCleanup]
+    public void Cleanup() => _db.Dispose();
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_ReturnsOnlyTransactionsForGivenAccount()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Grocery Store", categoryName: "Food", id: 1);
+        var t2 = MakeTransaction(accountId: 2, payee: "Grocery Store", categoryName: "Food", id: 2);
+        _db.Insert("Transactions", t1);
+        _db.Insert("Transactions", t2);
+
+        // Act
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "Grocery");
+
+        // Assert
+        Assert.HasCount(1, results);
+        Assert.AreEqual(1, results[0].AccountId);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_MatchesOnPayee_CaseInsensitive()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Amazon", categoryName: "Shopping", id: 1);
+        var t2 = MakeTransaction(accountId: 1, payee: "Netflix", categoryName: "Entertainment", id: 2);
+        _db.Insert("Transactions", t1);
+        _db.Insert("Transactions", t2);
+
+        // Act — uppercase query
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "AMAZON");
+
+        // Assert
+        Assert.HasCount(1, results);
+        Assert.AreEqual("Amazon", results[0].Payee);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_MatchesOnCategoryName_CaseInsensitive()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Store A", categoryName: "Groceries", id: 1);
+        var t2 = MakeTransaction(accountId: 1, payee: "Store B", categoryName: "Entertainment", id: 2);
+        _db.Insert("Transactions", t1);
+        _db.Insert("Transactions", t2);
+
+        // Act — mixed-case query
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "GROCERIES");
+
+        // Assert
+        Assert.HasCount(1, results);
+        Assert.AreEqual("Groceries", results[0].Category.Name);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_ReturnsEmptyList_WhenNoTransactionsMatch()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Amazon", categoryName: "Shopping", id: 1);
+        _db.Insert("Transactions", t1);
+
+        // Act
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "zzznomatch");
+
+        // Assert
+        Assert.IsEmpty(results);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_ReturnsEmptyList_WhenAccountHasNoTransactions()
+    {
+        // Arrange — no transactions inserted
+
+        // Act
+        var results = await _db.SearchTransactionsAsync(accountId: 99, query: "anything");
+
+        // Assert
+        Assert.IsEmpty(results);
+    }
+
+    [TestMethod]
+    public async Task SearchTransactionsAsync_PartialMatch_ReturnsMatchingTransactions()
+    {
+        // Arrange
+        var t1 = MakeTransaction(accountId: 1, payee: "Whole Foods Market", categoryName: "Groceries", id: 1);
+        var t2 = MakeTransaction(accountId: 1, payee: "Target", categoryName: "Shopping", id: 2);
+        _db.Insert("Transactions", t1);
+        _db.Insert("Transactions", t2);
+
+        // Act — partial payee match
+        var results = await _db.SearchTransactionsAsync(accountId: 1, query: "foods");
+
+        // Assert
+        Assert.HasCount(1, results);
+        Assert.AreEqual("Whole Foods Market", results[0].Payee);
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/LazyLoadingDuringSearch.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/LazyLoadingDuringSearch.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+using MyMoney.Services;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Tests.ViewModelTests.AccountsViewModel;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+
+[TestClass]
+public class LazyLoadingDuringSearch
+{
+    private Mock<IContentDialogService> _mockContentDialogService;
+    private Mock<IDatabaseManager> _mockDatabaseService;
+    private Mock<IMessageBoxService> _mockMessageBoxService;
+    private Mock<IContentDialogFactory> _mockContentDialogFactory;
+    private MyMoney.ViewModels.Pages.AccountsViewModel _viewModel;
+
+    private Account _testAccount;
+    private List<Transaction> _testTransactions;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _mockContentDialogService = new Mock<IContentDialogService>();
+        _mockDatabaseService = new Mock<IDatabaseManager>();
+        _mockMessageBoxService = new Mock<IMessageBoxService>();
+        _mockContentDialogFactory = new Mock<IContentDialogFactory>();
+
+        // Setup test account
+        _testAccount = new Account { Id = 1, AccountName = "Test Account", Total = new Currency(1000m) };
+
+        // Setup test transactions
+        _testTransactions = new List<Transaction>();
+        for (int i = 0; i < 50; i++)
+        {
+            _testTransactions.Add(new Transaction(
+                DateTime.Now.AddDays(-i),
+                "Payee " + i,
+                new Category { Name = "Category " + (i % 5), Group = "Group " + (i % 3) },
+                new Currency((decimal)(i * 10)), // Fixed: cast to decimal
+                "Memo " + i
+            ) { AccountId = 1, Id = i + 1 });
+        }
+
+        // Mock database operations
+        _mockDatabaseService.Setup(dm => dm.GetCollection<Account>("Accounts"))
+            .Returns(new List<Account> { _testAccount });
+
+        _mockDatabaseService.Setup(dm => dm.SearchTransactionsAsync(It.IsAny<int>(), It.IsAny<string>()))
+            .ReturnsAsync((int accountId, string query) =>
+                _testTransactions.Where(t =>
+                    t.Payee.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                    t.Category.Name.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+                    (!string.IsNullOrEmpty(t.Memo) && t.Memo.Contains(query, StringComparison.OrdinalIgnoreCase))
+                ).ToList()
+            );
+
+        _viewModel = new(
+            _mockContentDialogService.Object,
+            _mockDatabaseService.Object,
+            _mockMessageBoxService.Object,
+            _mockContentDialogFactory.Object
+        );
+    }
+
+    [TestMethod]
+    public async Task LoadTransactions_ShouldNotLoad_WhenSearchIsActive()
+    {
+        // Arrange
+        await _viewModel.SelectedAccountChanged();
+
+        // Act - Perform a search
+        _viewModel.SearchQuery = "Payee 1";
+        await Task.Delay(350); // Wait for debounce
+
+        // Verify search is active
+        var transactionsBefore = _viewModel.SelectedAccountTransactions.Count;
+
+        // Act - Try to load more transactions (simulate scroll)
+        await _viewModel.LoadTransactions();
+
+        // Assert - Transactions count should not change
+        Assert.AreEqual(transactionsBefore, _viewModel.SelectedAccountTransactions.Count,
+            "Transaction count should not change when loading during active search");
+    }
+}

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -53,6 +53,7 @@ namespace MyMoney.ViewModels.Pages
         private CancellationTokenSource? _searchDebounceTokenSource;
 
         private bool _isLoadingTransactions = false;
+        private bool _isSearchActive = false;
         private DateTime? _oldestLoadedDate;
         private int _oldestLoadedId;
         private const int PageSize = 25;
@@ -111,6 +112,10 @@ namespace MyMoney.ViewModels.Pages
 
         public async Task LoadTransactions()
         {
+            // Don't load more transactions if search is active
+            if (_isSearchActive)
+                return;
+
             if (_isLoadingTransactions)
                 return;
             _isLoadingTransactions = true;
@@ -125,7 +130,7 @@ namespace MyMoney.ViewModels.Pages
                         _oldestLoadedId,
                         PageSize
                     );
-                    
+
                     foreach (var transaction in page)
                     {
                         SelectedAccountTransactions.Add(transaction);
@@ -135,7 +140,7 @@ namespace MyMoney.ViewModels.Pages
                     {
                         _oldestLoadedId = page[page.Count - 1].Id;
                         _oldestLoadedDate = page[page.Count - 1].Date;
-                    } 
+                    }
                 }
             }
             finally
@@ -741,6 +746,7 @@ namespace MyMoney.ViewModels.Pages
                 oldCts?.Dispose();
             }
             SearchQuery = "";
+            _isSearchActive = false;
 
             IsInputEnabled = SelectedAccount != null;
             SelectedAccountTransactions.Clear();
@@ -803,6 +809,7 @@ namespace MyMoney.ViewModels.Pages
                 {
                     SelectedAccountTransactions.Add(transaction);
                 }
+                _isSearchActive = true;
             } );
         }
 
@@ -811,6 +818,7 @@ namespace MyMoney.ViewModels.Pages
             SelectedAccountTransactions.Clear();
             _oldestLoadedDate = null;
             _oldestLoadedId = 0;
+            _isSearchActive = false;
             await LoadTransactions();
         }
 

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.ObjectModel;
-using System.ComponentModel;
 using MyMoney.Core.Database;
 using MyMoney.Core.Models;
 using MyMoney.Services;
@@ -47,6 +46,12 @@ namespace MyMoney.ViewModels.Pages
 
         [ObservableProperty]
         private bool _isInputEnabled;
+
+        [ObservableProperty]
+        private string _searchQuery = "";
+
+        private bool _isInSearchMode = false;
+        private CancellationTokenSource? _searchDebounceTokenSource;
 
         private bool _isLoadingTransactions = false;
         private DateTime? _oldestLoadedDate;
@@ -728,7 +733,84 @@ namespace MyMoney.ViewModels.Pages
 
         public async Task SelectedAccountChanged()
         {
+            // Clear search state before reloading for the new account
+            if (_searchDebounceTokenSource != null)
+            {
+                _searchDebounceTokenSource.Cancel();
+                _searchDebounceTokenSource.Dispose();
+                _searchDebounceTokenSource = null;
+            }
+            SearchQuery = "";
+            _isInSearchMode = false;
+
             IsInputEnabled = SelectedAccount != null;
+            SelectedAccountTransactions.Clear();
+            _oldestLoadedDate = null;
+            _oldestLoadedId = 0;
+            await LoadTransactions();
+        }
+
+        partial void OnSearchQueryChanged(string value)
+        {
+            // Source updates are debounced (Binding.Delay on the search TextBox) so the
+            // view model and binding are not hit on every keypress. Search work still
+            // runs on a background thread to avoid blocking the UI.
+            _searchDebounceTokenSource?.Cancel();
+            _searchDebounceTokenSource?.Dispose();
+            _searchDebounceTokenSource = null;
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                _ = ClearSearchAndReloadAsync();
+                return;
+            }
+
+            var cts = new CancellationTokenSource();
+            _searchDebounceTokenSource = cts;
+            var ct = cts.Token;
+
+            _ = Task.Run(
+                async () =>
+                {
+                    try
+                    {
+                        await ExecuteSearchAsync(value, ct);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // Superseded by a newer search or account change — expected.
+                    }
+                },
+                ct
+            );
+        }
+
+        private async Task ExecuteSearchAsync(string query, CancellationToken ct)
+        {
+            if (SelectedAccount == null)
+                return;
+
+            var results = await _databaseManager.SearchTransactionsAsync(SelectedAccount.Id, query);
+
+            if (ct.IsCancellationRequested)
+                return;
+
+            // update with dispatcher
+            await App.Current.Dispatcher.InvokeAsync(() =>
+            {
+                SelectedAccountTransactions.Clear();
+                foreach (var transaction in results)
+                {
+                    SelectedAccountTransactions.Add(transaction);
+                }
+            } );
+
+            _isInSearchMode = true;
+        }
+
+        private async Task ClearSearchAndReloadAsync()
+        {
+            _isInSearchMode = false;
             SelectedAccountTransactions.Clear();
             _oldestLoadedDate = null;
             _oldestLoadedId = 0;

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -50,7 +50,6 @@ namespace MyMoney.ViewModels.Pages
         [ObservableProperty]
         private string _searchQuery = "";
 
-        private bool _isInSearchMode = false;
         private CancellationTokenSource? _searchDebounceTokenSource;
 
         private bool _isLoadingTransactions = false;
@@ -736,12 +735,12 @@ namespace MyMoney.ViewModels.Pages
             // Clear search state before reloading for the new account
             if (_searchDebounceTokenSource != null)
             {
-                _searchDebounceTokenSource.Cancel();
-                _searchDebounceTokenSource.Dispose();
+                var oldCts = _searchDebounceTokenSource;
                 _searchDebounceTokenSource = null;
+                oldCts?.Cancel();
+                oldCts?.Dispose();
             }
             SearchQuery = "";
-            _isInSearchMode = false;
 
             IsInputEnabled = SelectedAccount != null;
             SelectedAccountTransactions.Clear();
@@ -755,9 +754,10 @@ namespace MyMoney.ViewModels.Pages
             // Source updates are debounced (Binding.Delay on the search TextBox) so the
             // view model and binding are not hit on every keypress. Search work still
             // runs on a background thread to avoid blocking the UI.
-            _searchDebounceTokenSource?.Cancel();
-            _searchDebounceTokenSource?.Dispose();
+            var oldCts = _searchDebounceTokenSource;
             _searchDebounceTokenSource = null;
+            oldCts?.Cancel();
+            oldCts?.Dispose();
 
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -804,13 +804,10 @@ namespace MyMoney.ViewModels.Pages
                     SelectedAccountTransactions.Add(transaction);
                 }
             } );
-
-            _isInSearchMode = true;
         }
 
         private async Task ClearSearchAndReloadAsync()
         {
-            _isInSearchMode = false;
             SelectedAccountTransactions.Clear();
             _oldestLoadedDate = null;
             _oldestLoadedId = 0;

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -188,7 +188,9 @@
                         <ui:TextBox
                             Grid.Column="1"
                             Width="250"
-                            PlaceholderText="Search transactions">
+                            PlaceholderText="Search transactions"
+                            Text="{Binding ViewModel.SearchQuery, Delay=300, UpdateSourceTrigger=PropertyChanged}"
+                            IsEnabled="{Binding ViewModel.IsInputEnabled}">
                             <ui:TextBox.Icon>
                                 <ui:SymbolIcon Symbol="Search24" />
                             </ui:TextBox.Icon>


### PR DESCRIPTION
Added a new search feature for the transaction list that does a keyword search on transaction payee, category, and memo.

Closes #347 