### PR TITLE
Add progress bars to budget categories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,7 @@ MyMoney is a WPF application using MVVM pattern with:
 1. **Database Operations**: All database access goes through `DatabaseManager` interface
 2. **MVVM Pattern**: ViewModels expose properties and commands for Views to bind to
 5. **Testing**: Tests use in-memory database via `MemoryStream` for isolation
+
+## GitHub Interaction
+
+Use the `gh` CLI to interact with GitHub.

--- a/MyMoney/Converters/BudgetItemActualPercentageConverter.cs
+++ b/MyMoney/Converters/BudgetItemActualPercentageConverter.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using System.Windows.Data;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Converters
+{
+    public class BudgetItemActualPercentageConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 2 || values[0] is not Currency budgetedAmount || values[1] is not Currency actualAmount)
+            {
+                return 0d;
+            }
+
+            if (budgetedAmount.Value == 0m)
+            {
+                return 0d;
+            }
+
+            var percentage = (double)(actualAmount.Value / budgetedAmount.Value) * 100d;
+            return Math.Clamp(percentage, 0d, 100d);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MyMoney/Converters/BudgetItemProgressBarBrushConverter.cs
+++ b/MyMoney/Converters/BudgetItemProgressBarBrushConverter.cs
@@ -15,7 +15,7 @@ namespace MyMoney.Converters
             }
 
             // Get the item type from the third binding or from the parameter
-            string itemType = parameter as string;
+            string? itemType = parameter as string;
             if (values.Length >= 3 && values[2] is string typeFromBinding)
             {
                 itemType = typeFromBinding;

--- a/MyMoney/Converters/BudgetItemProgressBarBrushConverter.cs
+++ b/MyMoney/Converters/BudgetItemProgressBarBrushConverter.cs
@@ -1,0 +1,40 @@
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Converters
+{
+    public class BudgetItemProgressBarBrushConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Length < 2 || values[0] is not Currency budgetedAmount || values[1] is not Currency actualAmount)
+            {
+                return (SolidColorBrush)Application.Current.Resources["PositiveForegroundColorBrush"];
+            }
+
+            // Get the item type from the third binding or from the parameter
+            string itemType = parameter as string;
+            if (values.Length >= 3 && values[2] is string typeFromBinding)
+            {
+                itemType = typeFromBinding;
+            }
+
+            var isExpenseItem = itemType?.Equals("Expense", StringComparison.OrdinalIgnoreCase) ?? false;
+
+            var isOverspent = isExpenseItem && actualAmount.Value > budgetedAmount.Value;
+            if (isOverspent)
+            {
+                return new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0x55, 0x55));
+            }
+
+            return (SolidColorBrush)Application.Current.Resources["PositiveForegroundColorBrush"];
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MyMoney/Helpers/BudgetItemTypeHelper.cs
+++ b/MyMoney/Helpers/BudgetItemTypeHelper.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+
+namespace MyMoney.Helpers
+{
+    public static class BudgetItemTypeHelper
+    {
+        public static readonly DependencyProperty ItemTypeProperty =
+            DependencyProperty.RegisterAttached(
+                "ItemType",
+                typeof(string),
+                typeof(BudgetItemTypeHelper),
+                new PropertyMetadata("Income"));
+
+        public static string GetItemType(DependencyObject obj)
+        {
+            return (string)obj.GetValue(ItemTypeProperty);
+        }
+
+        public static void SetItemType(DependencyObject obj, string value)
+        {
+            obj.SetValue(ItemTypeProperty, value);
+        }
+    }
+}

--- a/MyMoney/Views/Controls/BudgetListViewItemStyle.xaml
+++ b/MyMoney/Views/Controls/BudgetListViewItemStyle.xaml
@@ -1,0 +1,101 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:converters="clr-namespace:MyMoney.Converters"
+    xmlns:helpers="clr-namespace:MyMoney.Helpers">
+
+    <converters:BudgetItemProgressBarBrushConverter x:Key="BudgetItemProgressBarBrushConverter" />
+    <converters:BudgetItemActualPercentageConverter x:Key="BudgetItemActualPercentageConverter" />
+
+    <Style x:Key="BudgetListViewItemStyleBase" TargetType="{x:Type ui:ListViewItem}">
+        <Setter Property="Foreground" Value="{DynamicResource ListViewItemForeground}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Border.CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Margin" Value="0,0,0,2" />
+        <Setter Property="Padding" Value="4" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ui:ListViewItem}">
+                    <Border
+                        x:Name="Border"
+                        Margin="0"
+                        Padding="0"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding Border.BorderBrush}"
+                        BorderThickness="{TemplateBinding Border.BorderThickness}"
+                        CornerRadius="{TemplateBinding Border.CornerRadius}">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <ui:GridViewRowPresenter
+                                Margin="{TemplateBinding Padding}"
+                                VerticalAlignment="{TemplateBinding Control.VerticalContentAlignment}"
+                                Columns="{TemplateBinding GridView.ColumnCollection}"
+                                Content="{TemplateBinding ContentControl.Content}" />
+
+                            <ProgressBar
+                                Grid.Row="1"
+                                Height="4"
+                                Margin="12,0,12,4"
+                                Maximum="100"
+                                Minimum="0">
+                                <ProgressBar.Foreground>
+                                    <MultiBinding Converter="{StaticResource BudgetItemProgressBarBrushConverter}">
+                                        <Binding Path="Amount" />
+                                        <Binding Path="Actual" />
+                                        <Binding Path="(helpers:BudgetItemTypeHelper.ItemType)" RelativeSource="{RelativeSource AncestorType={x:Type ui:ListViewItem}}" />
+                                    </MultiBinding>
+                                </ProgressBar.Foreground>
+                                <ProgressBar.Value>
+                                    <MultiBinding Converter="{StaticResource BudgetItemActualPercentageConverter}">
+                                        <Binding Path="Amount" />
+                                        <Binding Path="Actual" />
+                                    </MultiBinding>
+                                </ProgressBar.Value>
+                            </ProgressBar>
+
+                            <Rectangle
+                                x:Name="ActiveRectangle"
+                                Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Width="3"
+                                Height="18"
+                                Margin="0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Fill="{DynamicResource ListViewItemPillFillBrush}"
+                                RadiusX="2"
+                                RadiusY="2"
+                                Visibility="Collapsed" />
+                        </Grid>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsEnabled" Value="True" />
+                                <Condition Property="IsMouseOver" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+                        </MultiTrigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter TargetName="ActiveRectangle" Property="Visibility" Value="Visible" />
+                            <Setter TargetName="Border" Property="Background" Value="{DynamicResource ListViewItemBackgroundPointerOver}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="BudgetListViewItemStyle" TargetType="{x:Type ui:ListViewItem}" BasedOn="{StaticResource BudgetListViewItemStyleBase}">
+        <Setter Property="helpers:BudgetItemTypeHelper.ItemType" Value="Income" />
+    </Style>
+
+    <Style x:Key="BudgetListViewItemStyleExpense" TargetType="{x:Type ui:ListViewItem}" BasedOn="{StaticResource BudgetListViewItemStyleBase}">
+        <Setter Property="helpers:BudgetItemTypeHelper.ItemType" Value="Expense" />
+    </Style>
+
+</ResourceDictionary>

--- a/MyMoney/Views/Pages/BudgetPage.xaml
+++ b/MyMoney/Views/Pages/BudgetPage.xaml
@@ -30,6 +30,12 @@
             <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <converters:BooleanToInverseVisibilityConverter x:Key="BooleanToInverseVisibilityConverter" />
             <converters:IntToMonthNameConverter x:Key="IntToMonthNameConverter" />
+            <converters:BudgetItemActualPercentageConverter x:Key="BudgetItemActualPercentageConverter" />
+            <converters:BudgetItemProgressBarBrushConverter x:Key="BudgetItemProgressBarBrushConverter" />
+
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Views/Controls/BudgetListViewItemStyle.xaml" />
+            </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Page.Resources>
 
@@ -165,6 +171,9 @@
                                             Header="Actual" />
                                     </ui:GridView>
                                 </ui:ListView.View>
+                                <ui:ListView.ItemContainerStyle>
+                                    <StaticResource ResourceKey="BudgetListViewItemStyle" />
+                                </ui:ListView.ItemContainerStyle>
                             </ui:ListView>
 
                             <ui:Button
@@ -334,6 +343,9 @@
                                                         Header="Actual" />
                                                 </ui:GridView>
                                             </ui:ListView.View>
+                                            <ui:ListView.ItemContainerStyle>
+                                                <StaticResource ResourceKey="BudgetListViewItemStyleExpense" />
+                                            </ui:ListView.ItemContainerStyle>
                                         </ui:ListView>
 
                                         <ui:Button


### PR DESCRIPTION
Added progress bars to income and expense categories on budget page. They work the same way as the progress bars on the budget summary on the dashboard.

Closes #333 