### PR TITLE
Fix foreground of more button on accounts page

### DIFF
--- a/MyMoney/Views/Controls/MoreButton.xaml
+++ b/MyMoney/Views/Controls/MoreButton.xaml
@@ -1,16 +1,12 @@
-<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ControlTemplate x:Key="MoreButtonTemplate" TargetType="Button">
         <Border
+            Padding="{TemplateBinding Padding}"
             Background="{TemplateBinding Background}"
             BorderBrush="{TemplateBinding BorderBrush}"
             BorderThickness="{TemplateBinding BorderThickness}"
-            CornerRadius="4"
-            Padding="{TemplateBinding Padding}">
-            <ContentPresenter
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center" />
+            CornerRadius="4">
+            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
         </Border>
     </ControlTemplate>
 

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -141,7 +141,7 @@
                                     Style="{StaticResource MoreButtonStyle}"
                                     Click="MoreButton_Click"
                                     VerticalAlignment="Center">
-                                    <ui:SymbolIcon Symbol="MoreVertical24" FontSize="18"/>
+                                    <ui:SymbolIcon Symbol="MoreVertical24" FontSize="18" Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
                                 </Button>
                             </Grid>
                         </DataTemplate>


### PR DESCRIPTION
The foreground of the more button wasn't changing with the theme, so it was black on black in dark mode. This changes the symbol icon to use a dynamic resource for the foreground color.