### PR TITLE
Use central package management system

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,42 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/MyMoney/"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "07:00"
+      time: "06:00"
       timezone: "America/New_York"
     groups:
-      dependencies:
-        patterns:
-          - "*"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "nuget"
-    directory: "/MyMoney.Core/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "07:10"
-      timezone: "America/New_York"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "nuget"
-    directory: "/MyMoney.Tests/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "07:20"
-      timezone: "America/New_York"
-    groups:
-      dependencies:
+      all-dependencies:
         patterns:
           - "*"
     labels:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="gong-wpf-dragdrop" Version="4.0.0" />
+    <PackageVersion Include="LiteDB" Version="5.0.21" />
+    <PackageVersion Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageVersion Include="WPF-UI" Version="4.2.1" />
+  </ItemGroup>
+</Project>

--- a/MyMoney.Core/MyMoney.Core.csproj
+++ b/MyMoney.Core/MyMoney.Core.csproj
@@ -3,11 +3,10 @@
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-        <PackageReference Include="LiteDB" Version="5.0.21" />
+        <PackageReference Include="CommunityToolkit.Mvvm" />
+        <PackageReference Include="LiteDB" />
     </ItemGroup>
 </Project>

--- a/MyMoney.Core/packages.lock.json
+++ b/MyMoney.Core/packages.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "dependencies": {
     "net10.0": {
       "CommunityToolkit.Mvvm": {

--- a/MyMoney.Tests/MyMoney.Tests.csproj
+++ b/MyMoney.Tests/MyMoney.Tests.csproj
@@ -5,17 +5,16 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
-        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="10.0.0">
+        <PackageReference Include="coverlet.collector">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="MSTest.TestFramework" />
+        <PackageReference Include="MSTest.TestAdapter" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\MyMoney\MyMoney.csproj" />

--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "dependencies": {
     "net10.0-windows7.0": {
       "coverlet.collector": {
@@ -55,16 +55,6 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
-      "CommunityToolkit.Mvvm": {
-        "type": "Transitive",
-        "resolved": "8.4.2",
-        "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
-      },
-      "gong-wpf-dragdrop": {
-        "type": "Transitive",
-        "resolved": "4.0.0",
-        "contentHash": "nDj86v1XHhgmQR8PPo/uDDp/xdLDxcqZdvIwSxWAHQPiRX/GBXK13FYY0C2xQow9RSl6j5FKLk8xoYrdb52vqg=="
-      },
       "HarfBuzzSharp": {
         "type": "Transitive",
         "resolved": "8.3.1.1",
@@ -84,11 +74,6 @@
         "resolved": "8.3.1.1",
         "contentHash": "UsJtQsfAJoFDZrXc4hCUfRPMqccfKZ0iumJ/upcUjz/cmsTgVFGNEL5yaJWmkqsuFYdMWbj/En5/kS4PFl9hBA=="
       },
-      "LiteDB": {
-        "type": "Transitive",
-        "resolved": "5.0.21",
-        "contentHash": "ykJ7ffFl7P9YQKR/PLci6zupiLrsSCNkOTiw6OtzntH7d2kCYp5L1+3a/pksKgTEHcJBoPXFtg7VZSGVBseN9w=="
-      },
       "LiveChartsCore": {
         "type": "Transitive",
         "resolved": "2.0.1",
@@ -102,16 +87,6 @@
           "LiveChartsCore": "2.0.1",
           "SkiaSharp": "2.88.9",
           "SkiaSharp.HarfBuzz": "2.88.9"
-        }
-      },
-      "LiveChartsCore.SkiaSharpView.WPF": {
-        "type": "Transitive",
-        "resolved": "2.0.1",
-        "contentHash": "OYsjKd8cK2NTgY7FFJmLZtTtom6PRd6v+gOgooPMCE8lRyltHe8WRNTpTzNsA3aRAeWQLrwkiYZustGyJZERtg==",
-        "dependencies": {
-          "LiveChartsCore.SkiaSharpView": "2.0.1",
-          "SkiaSharp.HarfBuzz": "3.119.0",
-          "SkiaSharp.Views.WPF": "3.119.0"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -256,35 +231,6 @@
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
-      },
-      "Microsoft.Extensions.Hosting": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
-        "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.7",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
-          "Microsoft.Extensions.Configuration.Json": "10.0.7",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection": "10.0.7",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Diagnostics": "10.0.7",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging": "10.0.7",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
-          "Microsoft.Extensions.Logging.Console": "10.0.7",
-          "Microsoft.Extensions.Logging.Debug": "10.0.7",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
-          "Microsoft.Extensions.Options": "10.0.7"
-        }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
@@ -533,14 +479,6 @@
         "resolved": "10.0.7",
         "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
-      "WPF-UI": {
-        "type": "Transitive",
-        "resolved": "4.2.1",
-        "contentHash": "SgfFIzYtZWVsffgVXAy7QP8fSoBM6y33d5xUgDZGYGbNeIMEu49ZWJVG3rTWYO3Y+OxWWMrhIa+ER//OOi9t3Q==",
-        "dependencies": {
-          "WPF-UI.Abstractions": "4.2.1"
-        }
-      },
       "WPF-UI.Abstractions": {
         "type": "Transitive",
         "resolved": "4.2.1",
@@ -563,6 +501,74 @@
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "LiteDB": "[5.0.21, )"
+        }
+      },
+      "CommunityToolkit.Mvvm": {
+        "type": "CentralTransitive",
+        "requested": "[8.4.2, )",
+        "resolved": "8.4.2",
+        "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
+      },
+      "gong-wpf-dragdrop": {
+        "type": "CentralTransitive",
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "nDj86v1XHhgmQR8PPo/uDDp/xdLDxcqZdvIwSxWAHQPiRX/GBXK13FYY0C2xQow9RSl6j5FKLk8xoYrdb52vqg=="
+      },
+      "LiteDB": {
+        "type": "CentralTransitive",
+        "requested": "[5.0.21, )",
+        "resolved": "5.0.21",
+        "contentHash": "ykJ7ffFl7P9YQKR/PLci6zupiLrsSCNkOTiw6OtzntH7d2kCYp5L1+3a/pksKgTEHcJBoPXFtg7VZSGVBseN9w=="
+      },
+      "LiveChartsCore.SkiaSharpView.WPF": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "OYsjKd8cK2NTgY7FFJmLZtTtom6PRd6v+gOgooPMCE8lRyltHe8WRNTpTzNsA3aRAeWQLrwkiYZustGyJZERtg==",
+        "dependencies": {
+          "LiveChartsCore.SkiaSharpView": "2.0.1",
+          "SkiaSharp.HarfBuzz": "3.119.0",
+          "SkiaSharp.Views.WPF": "3.119.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "WPF-UI": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.1, )",
+        "resolved": "4.2.1",
+        "contentHash": "SgfFIzYtZWVsffgVXAy7QP8fSoBM6y33d5xUgDZGYGbNeIMEu49ZWJVG3rTWYO3Y+OxWWMrhIa+ER//OOi9t3Q==",
+        "dependencies": {
+          "WPF-UI.Abstractions": "4.2.1"
         }
       }
     }

--- a/MyMoney/MyMoney.csproj
+++ b/MyMoney/MyMoney.csproj
@@ -11,7 +11,6 @@
         <AssemblyVersion>1.2.0</AssemblyVersion>
         <FileVersion>1.2.0</FileVersion>
         <InformationalVersion>1.2.0</InformationalVersion>
-        <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     </PropertyGroup>
     <ItemGroup>
       <Compile Remove="Services\ContentDialogs\**" />
@@ -23,12 +22,12 @@
         <Content Include="MyMoney-icon.ico" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
-        <PackageReference Include="LiteDB" Version="5.0.21" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" Version="2.0.1" />
-        <PackageReference Include="WPF-UI" Version="4.2.1" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+        <PackageReference Include="gong-wpf-dragdrop" />
+        <PackageReference Include="LiteDB" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.WPF" />
+        <PackageReference Include="WPF-UI" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" />
+        <PackageReference Include="CommunityToolkit.Mvvm" />
     </ItemGroup>
     <ItemGroup>
         <None Remove="Assets\MyMoney-icon-256.png" />

--- a/MyMoney/packages.lock.json
+++ b/MyMoney/packages.lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "dependencies": {
     "net10.0-windows7.0": {
       "CommunityToolkit.Mvvm": {


### PR DESCRIPTION
Remove package version numbers from `.csproj` files and add a `Directory.Packages.props` file to the root of the repo for centralized package management. This should improve `dependabot` updates, since all package versions are in one file instead of three.