### PR TITLE
Add transaction CSV export from Accounts page

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="gong-wpf-dragdrop" Version="4.0.0" />
     <PackageVersion Include="LiteDB" Version="5.0.21" />

--- a/MyMoney.Core/Exports/ITransactionCsvExporter.cs
+++ b/MyMoney.Core/Exports/ITransactionCsvExporter.cs
@@ -1,0 +1,6 @@
+namespace MyMoney.Core.Exports;
+
+public interface ITransactionCsvExporter
+{
+    Task<TransactionCsvExportResult> ExportAsync(TransactionCsvExportOptions options);
+}

--- a/MyMoney.Core/Exports/TransactionCsvExportOptions.cs
+++ b/MyMoney.Core/Exports/TransactionCsvExportOptions.cs
@@ -1,0 +1,28 @@
+namespace MyMoney.Core.Exports;
+
+public enum TransactionExportField
+{
+    AccountName,
+    Reconciled,
+    Date,
+    Payee,
+    Category,
+    Amount,
+}
+
+public class TransactionCsvExportOptions
+{
+    public bool ExportAllAccounts { get; set; }
+
+    public int? AccountId { get; set; }
+
+    public bool UseDateRange { get; set; }
+
+    public DateTime? StartDate { get; set; }
+
+    public DateTime? EndDate { get; set; }
+
+    public IReadOnlyList<TransactionExportField> SelectedFields { get; set; } = [];
+
+    public required string OutputFilePath { get; init; }
+}

--- a/MyMoney.Core/Exports/TransactionCsvExportResult.cs
+++ b/MyMoney.Core/Exports/TransactionCsvExportResult.cs
@@ -1,0 +1,15 @@
+namespace MyMoney.Core.Exports;
+
+public class TransactionCsvExportResult
+{
+    public bool Success { get; init; }
+
+    public int RowCount { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public static TransactionCsvExportResult Succeeded(int rowCount) => new() { Success = true, RowCount = rowCount };
+
+    public static TransactionCsvExportResult Failed(string errorMessage) =>
+        new() { Success = false, ErrorMessage = errorMessage };
+}

--- a/MyMoney.Core/Exports/TransactionCsvExporter.cs
+++ b/MyMoney.Core/Exports/TransactionCsvExporter.cs
@@ -1,0 +1,117 @@
+using System.Globalization;
+using CsvHelper;
+using MyMoney.Core.Database;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Core.Exports;
+
+public class TransactionCsvExporter : ITransactionCsvExporter
+{
+    private readonly IDatabaseManager _databaseManager;
+
+    public TransactionCsvExporter(IDatabaseManager databaseManager)
+    {
+        _databaseManager = databaseManager ?? throw new ArgumentNullException(nameof(databaseManager));
+    }
+
+    public async Task<TransactionCsvExportResult> ExportAsync(TransactionCsvExportOptions options)
+    {
+        if (options.SelectedFields.Count == 0)
+        {
+            return TransactionCsvExportResult.Failed("At least one field must be selected.");
+        }
+
+        if (options.UseDateRange && (!options.StartDate.HasValue || !options.EndDate.HasValue))
+        {
+            return TransactionCsvExportResult.Failed("A start and end date are required for date-range exports.");
+        }
+
+        try
+        {
+            var transactions = await GetTransactionsAsync(options);
+            var accounts = _databaseManager.GetCollection<Account>("Accounts")
+                .ToDictionary(a => a.Id, a => a.AccountName);
+
+            await using var writer = new StreamWriter(options.OutputFilePath);
+            await using var csv = new CsvWriter(writer, CultureInfo.CurrentCulture);
+
+            foreach (var field in options.SelectedFields)
+            {
+                csv.WriteField(GetHeader(field));
+            }
+            await csv.NextRecordAsync();
+
+            foreach (var transaction in transactions)
+            {
+                foreach (var field in options.SelectedFields)
+                {
+                    csv.WriteField(GetValue(field, transaction, accounts));
+                }
+                await csv.NextRecordAsync();
+            }
+
+            return TransactionCsvExportResult.Succeeded(transactions.Count);
+        }
+        catch (Exception ex)
+        {
+            return TransactionCsvExportResult.Failed(ex.Message);
+        }
+    }
+
+    private async Task<List<Transaction>> GetTransactionsAsync(TransactionCsvExportOptions options)
+    {
+        List<Transaction> transactions = [];
+
+        await _databaseManager.QueryAsync<Transaction>("Transactions", query =>
+        {
+            var filtered = query;
+
+            if (!options.ExportAllAccounts && options.AccountId.HasValue)
+            {
+                var accountId = options.AccountId.Value;
+                filtered = filtered.Where(t => t.AccountId == accountId);
+            }
+
+            if (options.UseDateRange && options.StartDate.HasValue && options.EndDate.HasValue)
+            {
+                var start = options.StartDate.Value.Date;
+                var end = options.EndDate.Value.Date;
+                filtered = filtered.Where(t => t.Date >= start && t.Date <= end);
+            }
+
+            transactions = filtered.OrderBy(t => t.Date).ToList();
+
+            return Task.CompletedTask;
+        });
+
+        return transactions;
+    }
+
+    private static string GetHeader(TransactionExportField field) =>
+        field switch
+        {
+            TransactionExportField.AccountName => "Account Name",
+            TransactionExportField.Reconciled => "Reconciled",
+            TransactionExportField.Date => "Date",
+            TransactionExportField.Payee => "Payee",
+            TransactionExportField.Category => "Category",
+            TransactionExportField.Amount => "Amount",
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, null),
+        };
+
+    private static object GetValue(
+        TransactionExportField field,
+        Transaction transaction,
+        IReadOnlyDictionary<int, string> accountNames
+    ) =>
+        field switch
+        {
+            TransactionExportField.AccountName => accountNames.TryGetValue(transaction.AccountId, out var name) ? name : "",
+            TransactionExportField.Reconciled => transaction.Reconciled,
+            TransactionExportField.Date => transaction.Date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            TransactionExportField.Payee => transaction.Payee,
+            TransactionExportField.Category => transaction.Category?.Name ?? "",
+            TransactionExportField.Amount => transaction.Amount.Value,
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, null),
+        };
+}

--- a/MyMoney.Core/MyMoney.Core.csproj
+++ b/MyMoney.Core/MyMoney.Core.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.Mvvm" />
+        <PackageReference Include="CsvHelper" />
         <PackageReference Include="LiteDB" />
     </ItemGroup>
 </Project>

--- a/MyMoney.Core/packages.lock.json
+++ b/MyMoney.Core/packages.lock.json
@@ -8,6 +8,12 @@
         "resolved": "8.4.2",
         "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
       },
+      "CsvHelper": {
+        "type": "Direct",
+        "requested": "[33.1.0, )",
+        "resolved": "33.1.0",
+        "contentHash": "kqfTOZGrn7NarNeXgjh86JcpTHUoeQDMB8t9NVa/ZtlSYiV1rxfRnQ49WaJsob4AiGrbK0XDzpyKkBwai4F8eg=="
+      },
       "LiteDB": {
         "type": "Direct",
         "requested": "[5.0.21, )",

--- a/MyMoney.Tests/CoreTests/TransactionCsvExporterTests.cs
+++ b/MyMoney.Tests/CoreTests/TransactionCsvExporterTests.cs
@@ -1,0 +1,113 @@
+using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Tests.CoreTests;
+
+[TestClass]
+public class TransactionCsvExporterTests
+{
+    private DatabaseManager _databaseManager = null!;
+    private TransactionCsvExporter _exporter = null!;
+    private string _tempFilePath = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _databaseManager = new DatabaseManager(new MemoryStream());
+        _exporter = new TransactionCsvExporter(_databaseManager);
+        _tempFilePath = Path.Combine(Path.GetTempPath(), $"mymoney-export-{Guid.NewGuid():N}.csv");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _databaseManager.Dispose();
+        if (File.Exists(_tempFilePath))
+            File.Delete(_tempFilePath);
+    }
+
+    [TestMethod]
+    public async Task ExportAsync_SelectedAccountOnly_ExportsOnlyThatAccount()
+    {
+        _databaseManager.WriteCollection("Accounts", [
+            new Account { Id = 1, AccountName = "Checking", Total = new Currency(1000m) },
+            new Account { Id = 2, AccountName = "Savings", Total = new Currency(2000m) },
+        ]);
+
+        _databaseManager.WriteCollection("Transactions", [
+            new Transaction(new DateTime(2026, 4, 10), "Store A", new Category { Name = "Food" }, new Currency(-10m), "")
+            {
+                AccountId = 1,
+                Reconciled = true,
+            },
+            new Transaction(new DateTime(2026, 4, 11), "Store B", new Category { Name = "Travel" }, new Currency(-20m), "")
+            {
+                AccountId = 2,
+                Reconciled = false,
+            },
+        ]);
+
+        var result = await _exporter.ExportAsync(new TransactionCsvExportOptions
+        {
+            ExportAllAccounts = false,
+            AccountId = 1,
+            UseDateRange = false,
+            SelectedFields = [TransactionExportField.AccountName, TransactionExportField.Payee, TransactionExportField.Amount],
+            OutputFilePath = _tempFilePath,
+        });
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(1, result.RowCount);
+
+        var lines = File.ReadAllLines(_tempFilePath);
+        Assert.AreEqual("Account Name,Payee,Amount", lines[0]);
+        Assert.IsTrue(lines[1].Contains("Checking"));
+        Assert.IsTrue(lines[1].Contains("Store A"));
+        Assert.IsFalse(lines[1].Contains("Store B"));
+    }
+
+    [TestMethod]
+    public async Task ExportAsync_DateRangeInclusive_UsesSelectedColumnsInOrder()
+    {
+        _databaseManager.WriteCollection("Accounts", [
+            new Account { Id = 1, AccountName = "Checking", Total = new Currency(1000m) },
+        ]);
+
+        _databaseManager.WriteCollection("Transactions", [
+            new Transaction(new DateTime(2026, 4, 1), "Start", new Category { Name = "Cat1" }, new Currency(5m), "")
+            {
+                AccountId = 1,
+                Reconciled = true,
+            },
+            new Transaction(new DateTime(2026, 4, 30), "End", new Category { Name = "Cat2" }, new Currency(15m), "")
+            {
+                AccountId = 1,
+                Reconciled = false,
+            },
+            new Transaction(new DateTime(2026, 5, 1), "Outside", new Category { Name = "Cat3" }, new Currency(25m), "")
+            {
+                AccountId = 1,
+                Reconciled = false,
+            },
+        ]);
+
+        var result = await _exporter.ExportAsync(new TransactionCsvExportOptions
+        {
+            ExportAllAccounts = true,
+            UseDateRange = true,
+            StartDate = new DateTime(2026, 4, 1),
+            EndDate = new DateTime(2026, 4, 30),
+            SelectedFields = [TransactionExportField.Date, TransactionExportField.Reconciled, TransactionExportField.Payee],
+            OutputFilePath = _tempFilePath,
+        });
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(2, result.RowCount);
+
+        var lines = File.ReadAllLines(_tempFilePath);
+        Assert.AreEqual("Date,Reconciled,Payee", lines[0]);
+        Assert.AreEqual("2026-04-01,True,Start", lines[1]);
+        Assert.AreEqual("2026-04-30,False,End", lines[2]);
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteAccount.cs
@@ -1,5 +1,6 @@
 using Moq;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.Pages;
@@ -110,7 +111,9 @@ public class DeleteAccountTests
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            Mock.Of<IContentDialogFactory>()
+            Mock.Of<IContentDialogFactory>(),
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
     }
 }

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/DeleteTransaction.cs
@@ -1,6 +1,7 @@
 using System.Security.Principal;
 using Moq;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.Tests;
@@ -61,7 +62,10 @@ public class DeleteTransactionTest
             _mockContentDialogService.Object,
             _databaseManager,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object);
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
+        );
 
         _viewModel.SelectedAccount = _viewModel.Accounts[0];
         _viewModel.SelectedAccountIndex = 0;

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/EditTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/EditTransaction.cs
@@ -1,6 +1,7 @@
 using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
@@ -52,7 +53,9 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
                 _contentDialogService.Object,
                 _databaseManager,
                 _messageBoxService.Object,
-                _contentDialogFactory.Object
+                _contentDialogFactory.Object,
+                Mock.Of<IFileDialogService>(),
+                Mock.Of<ITransactionCsvExporter>()
             );
 
             _viewModel.SelectedAccount = _viewModel.Accounts[0];

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/ExportTransactions.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/ExportTransactions.cs
@@ -1,0 +1,132 @@
+using Moq;
+using MyMoney.Abstractions;
+using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
+using MyMoney.Core.Models;
+using MyMoney.Services;
+using MyMoney.ViewModels.ContentDialogs;
+using MyMoney.ViewModels.Pages;
+using MyMoney.Views.ContentDialogs;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Tests.ViewModelTests.AccountsViewModel;
+
+[TestClass]
+public class ExportTransactionsTests
+{
+    private Mock<IContentDialogService> _contentDialogServiceMock = null!;
+    private Mock<IMessageBoxService> _messageBoxServiceMock = null!;
+    private Mock<IContentDialogFactory> _contentDialogFactoryMock = null!;
+    private Mock<IFileDialogService> _fileDialogServiceMock = null!;
+    private Mock<ITransactionCsvExporter> _transactionCsvExporterMock = null!;
+    private DatabaseManager _databaseManager = null!;
+    private AccountsViewModel _viewModel = null!;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        _contentDialogServiceMock = new Mock<IContentDialogService>();
+        _messageBoxServiceMock = new Mock<IMessageBoxService>();
+        _contentDialogFactoryMock = new Mock<IContentDialogFactory>();
+        _fileDialogServiceMock = new Mock<IFileDialogService>();
+        _transactionCsvExporterMock = new Mock<ITransactionCsvExporter>();
+
+        _databaseManager = new DatabaseManager(new MemoryStream());
+        _databaseManager.WriteCollection("Accounts", [
+            new Account { AccountName = "Checking", Total = new Currency(1000m), Id = 1 },
+        ]);
+
+        _viewModel = new AccountsViewModel(
+            _contentDialogServiceMock.Object,
+            _databaseManager,
+            _messageBoxServiceMock.Object,
+            _contentDialogFactoryMock.Object,
+            _fileDialogServiceMock.Object,
+            _transactionCsvExporterMock.Object
+        );
+
+        await _viewModel.OnNavigatedToAsync();
+        _viewModel.SelectedAccount = _viewModel.Accounts[0];
+        _viewModel.SelectedAccountIndex = 0;
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _databaseManager.Dispose();
+    }
+
+    [TestMethod]
+    public async Task ExportTransactions_DialogCancelled_DoesNotInvokeExporter()
+    {
+        var fake = new Mock<IContentDialog>();
+        fake.SetupAllProperties();
+        fake.Setup(x => x.ShowAsync(It.IsAny<CancellationToken>())).ReturnsAsync(ContentDialogResult.Secondary);
+
+        _contentDialogFactoryMock.Setup(x => x.Create<ExportTransactionsDialog>()).Returns(fake.Object);
+
+        await _viewModel.ExportTransactionsCommand.ExecuteAsync(null);
+
+        _transactionCsvExporterMock.Verify(x => x.ExportAsync(It.IsAny<TransactionCsvExportOptions>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ExportTransactions_SaveDialogCancelled_DoesNotInvokeExporter()
+    {
+        var fake = new Mock<IContentDialog>();
+        fake.SetupAllProperties();
+        fake.Setup(x => x.ShowAsync(It.IsAny<CancellationToken>())).ReturnsAsync(ContentDialogResult.Primary);
+
+        _contentDialogFactoryMock.Setup(x => x.Create<ExportTransactionsDialog>()).Returns(fake.Object);
+        _fileDialogServiceMock
+            .Setup(x => x.ShowSaveCsvFileDialog(It.IsAny<string>()))
+            .Returns((string?)null);
+
+        await _viewModel.ExportTransactionsCommand.ExecuteAsync(null);
+
+        _transactionCsvExporterMock.Verify(x => x.ExportAsync(It.IsAny<TransactionCsvExportOptions>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task ExportTransactions_Success_UsesDialogOptionsAndCallsExporter()
+    {
+        var fake = new Mock<IContentDialog>();
+        fake.SetupAllProperties();
+        fake.Setup(x => x.ShowAsync(It.IsAny<CancellationToken>()))
+            .Callback(() =>
+            {
+                var vm = fake.Object.DataContext as ExportTransactionsDialogViewModel;
+                vm!.ExportCurrentAccount = true;
+                vm.ExportAllAccounts = false;
+                vm.UseDateRange = true;
+                vm.StartDate = new DateTime(2026, 4, 1);
+                vm.EndDate = new DateTime(2026, 4, 30);
+                vm.IncludeAccountName = false;
+            })
+            .ReturnsAsync(ContentDialogResult.Primary);
+
+        _contentDialogFactoryMock.Setup(x => x.Create<ExportTransactionsDialog>()).Returns(fake.Object);
+        _fileDialogServiceMock.Setup(x => x.ShowSaveCsvFileDialog(It.IsAny<string>())).Returns("C:\\temp\\out.csv");
+        _transactionCsvExporterMock
+            .Setup(x => x.ExportAsync(It.IsAny<TransactionCsvExportOptions>()))
+            .ReturnsAsync(TransactionCsvExportResult.Succeeded(4));
+
+        await _viewModel.ExportTransactionsCommand.ExecuteAsync(null);
+
+        _transactionCsvExporterMock.Verify(
+            x => x.ExportAsync(
+                It.Is<TransactionCsvExportOptions>(o =>
+                    !o.ExportAllAccounts
+                    && o.AccountId == 1
+                    && o.UseDateRange
+                    && o.StartDate == new DateTime(2026, 4, 1)
+                    && o.EndDate == new DateTime(2026, 4, 30)
+                    && o.OutputFilePath == "C:\\temp\\out.csv"
+                    && !o.SelectedFields.Contains(TransactionExportField.AccountName)
+                )
+            ),
+            Times.Once
+        );
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/ExportTransactions.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/ExportTransactions.cs
@@ -21,7 +21,7 @@ public class ExportTransactionsTests
     private Mock<IFileDialogService> _fileDialogServiceMock = null!;
     private Mock<ITransactionCsvExporter> _transactionCsvExporterMock = null!;
     private DatabaseManager _databaseManager = null!;
-    private AccountsViewModel _viewModel = null!;
+    private MyMoney.ViewModels.Pages.AccountsViewModel _viewModel = null!;
 
     [TestInitialize]
     public async Task Setup()
@@ -37,7 +37,7 @@ public class ExportTransactionsTests
             new Account { AccountName = "Checking", Total = new Currency(1000m), Id = 1 },
         ]);
 
-        _viewModel = new AccountsViewModel(
+        _viewModel = new (
             _contentDialogServiceMock.Object,
             _databaseManager,
             _messageBoxServiceMock.Object,

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/LazyLoadingDuringSearch.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/LazyLoadingDuringSearch.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using Wpf.Ui;
@@ -67,7 +68,9 @@ public class LazyLoadingDuringSearch
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
     }
 

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
@@ -49,7 +50,9 @@ public class NewAccountTest
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
         _viewModel.CreateNewAccountCommand.Execute(null);
 
@@ -77,7 +80,9 @@ public class NewAccountTest
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
         _viewModel.CreateNewAccountCommand.Execute(null);
 
@@ -101,7 +106,9 @@ public class NewAccountTest
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
         _viewModel.CreateNewAccountCommand.Execute(null);
 
@@ -129,7 +136,9 @@ public class NewAccountTest
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
 
         // Act - Create first account
@@ -165,7 +174,9 @@ public class NewAccountTest
             _mockContentDialogService.Object,
             _mockDatabaseService.Object,
             _mockMessageBoxService.Object,
-            _mockContentDialogFactory.Object
+            _mockContentDialogFactory.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
         Assert.IsFalse(_viewModel.TransactionsEnabled); // Initially disabled
 

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewTransaction.cs
@@ -3,6 +3,7 @@ using LiteDB;
 using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.Tests;
@@ -43,7 +44,9 @@ public class NewTransactionTests
             _contentDialogServiceMock.Object,
             _databaseManager,
             _messageBoxServiceMock.Object,
-            _contentDialogFactoryMock.Object
+            _contentDialogFactoryMock.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
 
         await _viewModel.OnNavigatedToAsync();

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/RenameAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/RenameAccount.cs
@@ -1,6 +1,7 @@
 ﻿using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
@@ -39,7 +40,9 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
                 _contentDialogService.Object,
                 _databaseReader.Object,
                 _messageBoxService.Object,
-                _contentDialogFactory.Object
+                _contentDialogFactory.Object,
+                Mock.Of<IFileDialogService>(),
+                Mock.Of<ITransactionCsvExporter>()
             );
 
             var account = new Account { AccountName = "Old Name" };
@@ -75,7 +78,9 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
                 _contentDialogService.Object,
                 _databaseReader.Object,
                 _messageBoxService.Object,
-                _contentDialogFactory.Object
+                _contentDialogFactory.Object,
+                Mock.Of<IFileDialogService>(),
+                Mock.Of<ITransactionCsvExporter>()
             );
 
             var account = new Account { AccountName = "Original Name" };

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/Transfer.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/Transfer.cs
@@ -5,6 +5,7 @@ using LiteDB;
 using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.Tests;
@@ -48,7 +49,9 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
                 _mockContentDialogService.Object,
                 _databaseManager,
                 _mockMessageBoxService.Object,
-                _mockContentDialogFactory.Object
+                _mockContentDialogFactory.Object,
+                Mock.Of<IFileDialogService>(),
+                Mock.Of<ITransactionCsvExporter>()
             );
             await _viewModel.OnNavigatedToAsync();
         }

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateAccountBalance.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateAccountBalance.cs
@@ -1,6 +1,7 @@
 using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
@@ -35,7 +36,9 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
                 _contentDialogService.Object,
                 _databaseReader.Object,
                 _messageBoxService.Object,
-                _contentDialogFactory.Object
+                _contentDialogFactory.Object,
+                Mock.Of<IFileDialogService>(),
+                Mock.Of<ITransactionCsvExporter>()
             );
         }
 

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateSavingsCategory.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateSavingsCategory.cs
@@ -3,6 +3,7 @@ using LiteDB;
 using Moq;
 using MyMoney.Abstractions;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.Tests;
@@ -51,7 +52,9 @@ public class UpdateSavingsCategoryTests
             _contentDialogServiceMock.Object,
             _databaseManager,
             _messageBoxServiceMock.Object,
-            _contentDialogFactoryMock.Object
+            _contentDialogFactoryMock.Object,
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
         );
 
         var fake = new Mock<IContentDialog>();

--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -500,6 +500,7 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
+          "CsvHelper": "[33.1.0, )",
           "LiteDB": "[5.0.21, )"
         }
       },
@@ -508,6 +509,12 @@
         "requested": "[8.4.2, )",
         "resolved": "8.4.2",
         "contentHash": "WadCzGEc2U+3e20avRLng4qNtt4zoOGWrdUISqJWrHe3/FSnrYjuM5Sb4yQb09LhkBXrrI4Zt3dLKgRMbItsrg=="
+      },
+      "CsvHelper": {
+        "type": "CentralTransitive",
+        "requested": "[33.1.0, )",
+        "resolved": "33.1.0",
+        "contentHash": "kqfTOZGrn7NarNeXgjh86JcpTHUoeQDMB8t9NVa/ZtlSYiV1rxfRnQ49WaJsob4AiGrbK0XDzpyKkBwai4F8eg=="
       },
       "gong-wpf-dragdrop": {
         "type": "CentralTransitive",

--- a/MyMoney/App.xaml.cs
+++ b/MyMoney/App.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Services;
 using MyMoney.ViewModels.Pages;
 using MyMoney.ViewModels.Windows;
@@ -77,8 +78,10 @@ namespace MyMoney
 
                     // Database
                     services.AddSingleton<IDatabaseManager, DatabaseManager>();
+                    services.AddTransient<ITransactionCsvExporter, TransactionCsvExporter>();
 
                     services.AddSingleton<IContentDialogFactory, ContentDialogFactory>();
+                    services.AddTransient<IFileDialogService, FileDialogService>();
 
                     services.AddTransient<IMessageBoxService, MessageBoxService>();
                 }

--- a/MyMoney/Services/FileDialogService.cs
+++ b/MyMoney/Services/FileDialogService.cs
@@ -1,0 +1,25 @@
+using Microsoft.Win32;
+
+namespace MyMoney.Services;
+
+public interface IFileDialogService
+{
+    string? ShowSaveCsvFileDialog(string defaultFileName);
+}
+
+public class FileDialogService : IFileDialogService
+{
+    public string? ShowSaveCsvFileDialog(string defaultFileName)
+    {
+        var dialog = new SaveFileDialog
+        {
+            Filter = "CSV files|*.csv",
+            DefaultExt = ".csv",
+            AddExtension = true,
+            Title = "Export transactions to CSV",
+            FileName = defaultFileName,
+        };
+
+        return dialog.ShowDialog() == true ? dialog.FileName : null;
+    }
+}

--- a/MyMoney/ViewModels/ContentDialogs/ExportTransactionsDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/ExportTransactionsDialogViewModel.cs
@@ -1,0 +1,101 @@
+using MyMoney.Core.Exports;
+
+namespace MyMoney.ViewModels.ContentDialogs;
+
+public partial class ExportTransactionsDialogViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private bool _exportCurrentAccount = true;
+
+    [ObservableProperty]
+    private bool _exportAllAccounts;
+
+    [ObservableProperty]
+    private bool _exportAllDates = true;
+
+    [ObservableProperty]
+    private bool _useDateRange;
+
+    [ObservableProperty]
+    private DateTime _startDate = DateTime.Today.AddMonths(-1);
+
+    [ObservableProperty]
+    private DateTime _endDate = DateTime.Today;
+
+    [ObservableProperty]
+    private bool _includeAccountName = true;
+
+    [ObservableProperty]
+    private bool _includeReconciled = true;
+
+    [ObservableProperty]
+    private bool _includeDate = true;
+
+    [ObservableProperty]
+    private bool _includePayee = true;
+
+    [ObservableProperty]
+    private bool _includeCategory = true;
+
+    [ObservableProperty]
+    private bool _includeAmount = true;
+
+    public bool HasSelectedFields =>
+        IncludeAccountName
+        || IncludeReconciled
+        || IncludeDate
+        || IncludePayee
+        || IncludeCategory
+        || IncludeAmount;
+
+    public IReadOnlyList<TransactionExportField> GetSelectedFields()
+    {
+        var fields = new List<TransactionExportField>();
+
+        if (IncludeAccountName)
+            fields.Add(TransactionExportField.AccountName);
+        if (IncludeReconciled)
+            fields.Add(TransactionExportField.Reconciled);
+        if (IncludeDate)
+            fields.Add(TransactionExportField.Date);
+        if (IncludePayee)
+            fields.Add(TransactionExportField.Payee);
+        if (IncludeCategory)
+            fields.Add(TransactionExportField.Category);
+        if (IncludeAmount)
+            fields.Add(TransactionExportField.Amount);
+
+        return fields;
+    }
+
+    partial void OnExportCurrentAccountChanged(bool value)
+    {
+        if (value)
+            ExportAllAccounts = false;
+    }
+
+    partial void OnExportAllAccountsChanged(bool value)
+    {
+        if (value)
+            ExportCurrentAccount = false;
+    }
+
+    partial void OnExportAllDatesChanged(bool value)
+    {
+        if (value)
+            UseDateRange = false;
+    }
+
+    partial void OnUseDateRangeChanged(bool value)
+    {
+        if (value)
+            ExportAllDates = false;
+    }
+
+    partial void OnIncludeAccountNameChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnIncludeReconciledChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnIncludeDateChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnIncludePayeeChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnIncludeCategoryChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnIncludeAmountChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+}

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
@@ -63,6 +64,8 @@ namespace MyMoney.ViewModels.Pages
         private readonly IDatabaseManager _databaseManager;
         private readonly IMessageBoxService _messageBoxService;
         private readonly IContentDialogFactory _contentDialogFactory;
+        private readonly IFileDialogService _fileDialogService;
+        private readonly ITransactionCsvExporter _transactionCsvExporter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AccountsViewModel"/> class.
@@ -75,13 +78,17 @@ namespace MyMoney.ViewModels.Pages
             IContentDialogService contentDialogService,
             IDatabaseManager databaseManager,
             IMessageBoxService messageBoxService,
-            IContentDialogFactory contentDialogFactory
+            IContentDialogFactory contentDialogFactory,
+            IFileDialogService fileDialogService,
+            ITransactionCsvExporter transactionCsvExporter
         )
         {
             _contentDialogService = contentDialogService;
             _databaseManager = databaseManager;
             _messageBoxService = messageBoxService;
             _contentDialogFactory = contentDialogFactory;
+            _fileDialogService = fileDialogService;
+            _transactionCsvExporter = transactionCsvExporter;
 
             LoadAccounts();
         }
@@ -681,6 +688,63 @@ namespace MyMoney.ViewModels.Pages
             _databaseManager.Update("Transactions", transaction);
         }
 
+        [RelayCommand]
+        private async Task ExportTransactions()
+        {
+            if (SelectedAccount == null && Accounts.Count == 0)
+                return;
+
+            var viewModel = new ExportTransactionsDialogViewModel();
+            var dialog = _contentDialogFactory.Create<ExportTransactionsDialog>();
+            dialog.Title = "Export Transactions";
+            dialog.PrimaryButtonText = "Export";
+            dialog.CloseButtonText = "Cancel";
+            dialog.DataContext = viewModel;
+            dialog.DialogHostEx = _contentDialogService.GetDialogHostEx();
+
+            var result = await dialog.ShowAsync();
+            if (result != ContentDialogResult.Primary)
+                return;
+
+            if (viewModel.ExportCurrentAccount && SelectedAccount == null)
+            {
+                await _messageBoxService.ShowInfoAsync("Error", "No account is currently selected.", "OK");
+                return;
+            }
+
+            var outputPath = _fileDialogService.ShowSaveCsvFileDialog($"transactions-{DateTime.Now:yyyy-MM-dd}.csv");
+            if (string.IsNullOrWhiteSpace(outputPath))
+                return;
+
+            var exportOptions = new TransactionCsvExportOptions
+            {
+                ExportAllAccounts = viewModel.ExportAllAccounts,
+                AccountId = viewModel.ExportCurrentAccount ? SelectedAccount?.Id : null,
+                UseDateRange = viewModel.UseDateRange,
+                StartDate = viewModel.UseDateRange ? viewModel.StartDate.Date : null,
+                EndDate = viewModel.UseDateRange ? viewModel.EndDate.Date : null,
+                SelectedFields = viewModel.GetSelectedFields(),
+                OutputFilePath = outputPath,
+            };
+
+            var exportResult = await _transactionCsvExporter.ExportAsync(exportOptions);
+            if (!exportResult.Success)
+            {
+                await _messageBoxService.ShowInfoAsync(
+                    "Export Failed",
+                    exportResult.ErrorMessage ?? "Unable to export transactions.",
+                    "OK"
+                );
+                return;
+            }
+
+            await _messageBoxService.ShowInfoAsync(
+                "Export Complete",
+                $"Successfully exported {exportResult.RowCount} transactions.",
+                "OK"
+            );
+        }
+
         private bool EnsureAccountSelected()
         {
             if (SelectedAccount != null)
@@ -828,3 +892,6 @@ namespace MyMoney.ViewModels.Pages
         }
     }
 }
+
+
+

--- a/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
@@ -23,14 +23,10 @@
 
     <StackPanel Margin="1,0,1,0">
         <ui:TextBlock Margin="0,0,0,4">Accounts to export</ui:TextBlock>
-        <Grid Margin="0,0,0,16" MinWidth="400">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*" />
-                <ColumnDefinition Width="1*" />
-            </Grid.ColumnDefinitions>
-            <RadioButton Grid.Column="0" IsChecked="{Binding ExportCurrentAccount}">Currently selected account</RadioButton>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,16">
+            <RadioButton Grid.Column="0" IsChecked="{Binding ExportCurrentAccount}" Margin="0,0,12,0">Currently selected account</RadioButton>
             <RadioButton Grid.Column="1" IsChecked="{Binding ExportAllAccounts}">All accounts</RadioButton>
-        </Grid>
+        </StackPanel>
 
         <ui:TextBlock Margin="0,0,0,4">Date scope</ui:TextBlock>
         <Grid Margin="0,0,0,8">

--- a/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
@@ -1,0 +1,75 @@
+<ui:ContentDialog
+    x:Class="MyMoney.Views.ContentDialogs.ExportTransactionsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="Export Transactions"
+    d:DataContext="{d:DesignInstance {x:Type contentdialogs:ExportTransactionsDialogViewModel},
+                                     IsDesignTimeCreatable=False}"
+    d:DesignHeight="540"
+    d:DesignWidth="760"
+    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    Closing="ContentDialog_Closing"
+    Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+    mc:Ignorable="d">
+    <ui:ContentDialog.Resources>
+        <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:ExportTransactionsDialog}" />
+    </ui:ContentDialog.Resources>
+
+    <StackPanel Margin="1,0,1,0">
+        <ui:TextBlock Margin="0,0,0,4">Accounts to export</ui:TextBlock>
+        <Grid Margin="0,0,0,16" MinWidth="400">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <RadioButton Grid.Column="0" IsChecked="{Binding ExportCurrentAccount}">Currently selected account</RadioButton>
+            <RadioButton Grid.Column="1" IsChecked="{Binding ExportAllAccounts}">All accounts</RadioButton>
+        </Grid>
+
+        <ui:TextBlock Margin="0,0,0,4">Date scope</ui:TextBlock>
+        <Grid Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+            <RadioButton Grid.Column="0" IsChecked="{Binding ExportAllDates}">All transactions</RadioButton>
+            <RadioButton Grid.Column="1" IsChecked="{Binding UseDateRange}">Date range</RadioButton>
+        </Grid>
+
+        <Grid Margin="0,0,0,16" IsEnabled="{Binding UseDateRange}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="12" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <DatePicker SelectedDate="{Binding StartDate}" SelectedDateFormat="Short" />
+            <DatePicker Grid.Column="2" SelectedDate="{Binding EndDate}" SelectedDateFormat="Short" />
+        </Grid>
+
+        <ui:TextBlock Margin="0,0,0,8">Fields to include</ui:TextBlock>
+        <Border
+            x:Name="FieldsBorder"
+            Margin="0,0,0,8"
+            Padding="8"
+            BorderBrush="Transparent"
+            BorderThickness="1"
+            CornerRadius="8">
+            <UniformGrid Columns="2" Rows="3">
+                <CheckBox IsChecked="{Binding IncludeAccountName}">Account name</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeReconciled}">Reconciled</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeDate}">Date</CheckBox>
+                <CheckBox IsChecked="{Binding IncludePayee}">Payee</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeCategory}">Category</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeAmount}">Amount</CheckBox>
+            </UniformGrid>
+        </Border>
+
+        <TextBlock x:Name="ValidationText" Foreground="Red" Visibility="Collapsed" />
+    </StackPanel>
+</ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml.cs
@@ -1,0 +1,44 @@
+using System.Windows;
+using System.Windows.Media;
+using MyMoney.Abstractions;
+using MyMoney.ViewModels.ContentDialogs;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Views.ContentDialogs;
+
+public partial class ExportTransactionsDialog : ContentDialog, IContentDialog
+{
+    public ExportTransactionsDialog()
+    {
+        InitializeComponent();
+    }
+
+    private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
+    {
+        if (args.Result != ContentDialogResult.Primary)
+            return;
+
+        if (DataContext is not ExportTransactionsDialogViewModel viewModel)
+            return;
+
+        var hasError = false;
+        ValidationText.Visibility = Visibility.Collapsed;
+        FieldsBorder.BorderBrush = Brushes.Transparent;
+
+        if (!viewModel.HasSelectedFields)
+        {
+            hasError = true;
+            FieldsBorder.BorderBrush = Brushes.Red;
+            ValidationText.Text = "Select at least one field.";
+            ValidationText.Visibility = Visibility.Visible;
+        }
+        else if (viewModel.UseDateRange && viewModel.StartDate.Date > viewModel.EndDate.Date)
+        {
+            hasError = true;
+            ValidationText.Text = "Start date must be on or before end date.";
+            ValidationText.Visibility = Visibility.Visible;
+        }
+
+        args.Cancel = hasError;
+    }
+}

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -200,6 +200,7 @@
                             Grid.Column="2"
                             Margin="8,0"
                             VerticalAlignment="Stretch"
+                            Command="{Binding ViewModel.ExportTransactionsCommand}"
                             ToolTip="Export as CSV">
                             <ui:SymbolIcon Symbol="ArrowExportLtr24" />
                         </ui:Button>

--- a/MyMoney/packages.lock.json
+++ b/MyMoney/packages.lock.json
@@ -422,8 +422,15 @@
         "type": "Project",
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
+          "CsvHelper": "[33.1.0, )",
           "LiteDB": "[5.0.21, )"
         }
+      },
+      "CsvHelper": {
+        "type": "CentralTransitive",
+        "requested": "[33.1.0, )",
+        "resolved": "33.1.0",
+        "contentHash": "kqfTOZGrn7NarNeXgjh86JcpTHUoeQDMB8t9NVa/ZtlSYiV1rxfRnQ49WaJsob4AiGrbK0XDzpyKkBwai4F8eg=="
       }
     }
   }


### PR DESCRIPTION
## Summary
- Added a new export settings dialog for transactions with account scope, date range, and selectable fields.
- Implemented a Core-layer CSV exporter with CsvHelper to filter transactions and write the selected columns.
- Wired the Accounts page export button to a new view-model command and standard save file dialog flow.
- Added unit tests for exporter filtering/output and AccountsViewModel export behavior.

## Testing
- Added Core tests covering account filtering, inclusive date ranges, and CSV column order/output.
- Added AccountsViewModel tests for dialog cancel, save-dialog cancel, and successful export wiring.
- Not run (not requested)