### PR TITLE
Improve build system for sandboxed agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 *.exe
 .idea/
 Docs/site
+.sandbox-tmp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,17 @@ the WPF-UI package for a WinUI 3 theme.
 - **Run single test**: `dotnet test --filter "Fully.Qualified.Test.Name"`
 - **Lint**: Uses built-in .editorconfig for C# formatting (no separate lint command)
 
+### Sandbox build/test commands
+
+When working inside a restricted sandbox, use `build-sandbox.ps1` from the solution directory.
+This script redirects temp and NuGet cache paths to `.sandbox-tmp/` in the repo so MSBuild/NuGet
+do not use blocked user temp locations.
+
+- **Sandbox restore**: `.\build-sandbox.ps1 -Command restore`
+- **Sandbox build**: `.\build-sandbox.ps1 -Command build`
+- **Sandbox run all tests**: `.\build-sandbox.ps1 -Command test`
+- **Sandbox run single test**: `.\build-sandbox.ps1 -Command test -TestFilter "Fully.Qualified.Test.Name"`
+
 ## High-level Architecture
 
 MyMoney is a WPF application using MVVM pattern with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/build-sandbox.ps1
+++ b/build-sandbox.ps1
@@ -1,0 +1,65 @@
+param(
+    [ValidateSet("restore", "build", "test")]
+    [string]$Command = "build",
+
+    [string]$TestFilter
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sandboxTmp = Join-Path $repoRoot ".sandbox-tmp"
+
+$paths = @(
+    $sandboxTmp,
+    (Join-Path $sandboxTmp "nuget-packages"),
+    (Join-Path $sandboxTmp "nuget-http"),
+    (Join-Path $sandboxTmp "nuget-scratch"),
+    (Join-Path $sandboxTmp "dotnet-home")
+)
+
+foreach ($path in $paths) {
+    New-Item -ItemType Directory -Force -Path $path | Out-Null
+}
+
+$env:TEMP = $sandboxTmp
+$env:TMP = $sandboxTmp
+$env:TMPDIR = $sandboxTmp
+
+$env:DOTNET_CLI_HOME = Join-Path $sandboxTmp "dotnet-home"
+$env:NUGET_PACKAGES = Join-Path $sandboxTmp "nuget-packages"
+$env:NUGET_HTTP_CACHE_PATH = Join-Path $sandboxTmp "nuget-http"
+$env:NUGET_SCRATCH = Join-Path $sandboxTmp "nuget-scratch"
+
+$env:DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE = "1"
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "1"
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+$env:DOTNET_ADD_GLOBAL_TOOLS_TO_PATH = "0"
+$env:DOTNET_GENERATE_ASPNET_CERTIFICATE = "0"
+
+Push-Location $repoRoot
+try {
+    if ($Command -eq "restore") {
+        dotnet restore --ignore-failed-sources
+        exit $LASTEXITCODE
+    }
+
+    dotnet restore --ignore-failed-sources
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+    if ($Command -eq "build") {
+        dotnet build --no-restore
+        exit $LASTEXITCODE
+    }
+
+    if ($TestFilter) {
+        dotnet test --no-restore --filter $TestFilter
+        exit $LASTEXITCODE
+    }
+
+    dotnet test --no-restore
+    exit $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
Agents that run in a sandbox, such as OpenAI Codex, are having problems building the project. This PR introduces a new script that sets some environment variables so that `MSBuild` and `dotnet` don't try to access `tmp` directories outside the sandbox. It also suppresses the `NU1701` warnings from transitive dependencies.