### PR TITLE
Add dialog validation coverage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
-    <PackageVersion Include="NCalcSync" Version="6.2.0" />
+    <PackageVersion Include="NCalcSync" Version="6.3.0" />
     <PackageVersion Include="WPF-UI" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/MyMoney.Core/MyMoney.Core.csproj
+++ b/MyMoney.Core/MyMoney.Core.csproj
@@ -9,5 +9,6 @@
         <PackageReference Include="CommunityToolkit.Mvvm" />
         <PackageReference Include="CsvHelper" />
         <PackageReference Include="LiteDB" />
+        <PackageReference Include="NCalcSync" />
     </ItemGroup>
 </Project>

--- a/MyMoney.Core/Services/CurrencyExpressionParser.cs
+++ b/MyMoney.Core/Services/CurrencyExpressionParser.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MyMoney.Core.Models;
+
+namespace MyMoney.Core.Services
+{
+    public class CurrencyExpressionParser
+    {
+        public static bool TryEvaluate(string expression, out decimal amount, out string? error)
+        {
+            try
+            {
+                // Strip dollar signs
+                expression = expression.Replace("$", "").Trim();
+
+                // Strip commas
+                expression = expression.Replace(",", "");
+
+                // Evaluate with NCalc
+                var expr = new NCalc.Expression(expression);
+
+                var result = System.Convert.ToDecimal(expr.Evaluate());
+
+                amount = result;
+                error = null;
+                return true;
+            }
+            catch (Exception e)
+            {
+                error = e.Message;
+                amount = 0;
+                return false;
+            }
+        }
+    }
+}

--- a/MyMoney.Core/packages.lock.json
+++ b/MyMoney.Core/packages.lock.json
@@ -19,6 +19,63 @@
         "requested": "[5.0.21, )",
         "resolved": "5.0.21",
         "contentHash": "ykJ7ffFl7P9YQKR/PLci6zupiLrsSCNkOTiw6OtzntH7d2kCYp5L1+3a/pksKgTEHcJBoPXFtg7VZSGVBseN9w=="
+      },
+      "NCalcSync": {
+        "type": "Direct",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "r02xI0zZB12Cxelz136/CxyMGNfmXWnxQUXohLaTdXxitVZafEKSaQWuabJwBVrRDCu9Cr09gAKWooplZoS5iw==",
+        "dependencies": {
+          "NCalc.Core": "6.3.0"
+        }
+      },
+      "ExtendedNumerics.BigDecimal": {
+        "type": "Transitive",
+        "resolved": "3003.0.0.346",
+        "contentHash": "o6qdyacVFNvDKX6T0sDEdhMKppdCiTwpj22kdgNfQlIviLSAiLqv/i4G/gYL4ZzqBYzR/o3t8wDWCX21Tt/i1A=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "NCalc.Core": {
+        "type": "Transitive",
+        "resolved": "6.3.0",
+        "contentHash": "DYhNhLVUQk5bNQBVeHoReZqFdR4WU5kptIfjIJHRRNPs7Ph+fOlxVpfwONVG1i0sBlnFQ2mEexCSXcKhfWGI2Q==",
+        "dependencies": {
+          "ExtendedNumerics.BigDecimal": "3003.0.0.346",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "NCalc.Parser": "6.3.0",
+          "Parlot": "1.5.7"
+        }
+      },
+      "NCalc.Domain": {
+        "type": "Transitive",
+        "resolved": "6.3.0",
+        "contentHash": "MUuFquLKiW4WwuGK4rSZEZYPxD1j6ZX21dxSpQbHfUnR7oIsV71rkhvMOb1mafQgsZrlSa9c8xBbKrlLxmOPfQ=="
+      },
+      "NCalc.Parser": {
+        "type": "Transitive",
+        "resolved": "6.3.0",
+        "contentHash": "YMbau/slMZuyAJhcyF/hoa2bG7OLjLcboo13BOWOuK//DzuxM4YQtetQO4hODxkrHSdieELVfRV03Vn9bq7Sog==",
+        "dependencies": {
+          "NCalc.Domain": "6.3.0",
+          "Parlot": "1.5.7"
+        }
+      },
+      "Parlot": {
+        "type": "Transitive",
+        "resolved": "1.5.7",
+        "contentHash": "D0PhSypMx1JJVTQUqB8ebwcJxH4NAvdn1d8eKi9lLoNz8c1+8qHw+/Sq5/6HaJFgOaqy1VJBpvYFCIC4I2uvqQ=="
       }
     }
   }

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/NewAccount.cs
@@ -186,6 +186,20 @@ public class NewAccountTest
         Assert.IsTrue(_viewModel.TransactionsEnabled);
     }
 
+    [TestMethod]
+    public void StartingBalanceStr_WhenClearedAfterNonZeroBalance_RemainsBlankAndHasValidationError()
+    {
+        // Arrange
+        var viewModel = new NewAccountDialogViewModel { StartingBalance = new Currency(100m) };
+
+        // Act
+        viewModel.StartingBalanceStr = "";
+
+        // Assert
+        Assert.AreEqual("", viewModel.StartingBalanceStr);
+        Assert.IsTrue(viewModel.HasErrors);
+    }
+
     private void SetupMockDialogSuccess(NewAccountDialogViewModel dialogViewModel)
     {
         var fake = new Mock<IContentDialog>();

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateAccountBalance.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/UpdateAccountBalance.cs
@@ -71,5 +71,19 @@ namespace MyMoney.Tests.ViewModelTests.AccountsViewModel
             // Assert
             Assert.AreEqual(150m, _viewModel.Accounts[0].Total.Value);
         }
+
+        [TestMethod]
+        public void BalanceStr_WhenClearedAfterNonZeroBalance_RemainsBlankAndHasValidationError()
+        {
+            // Arrange
+            var viewModel = new UpdateAccountBalanceDialogViewModel { Balance = new Currency(100m) };
+
+            // Act
+            viewModel.BalanceStr = "";
+
+            // Assert
+            Assert.AreEqual("", viewModel.BalanceStr);
+            Assert.IsTrue(viewModel.HasErrors);
+        }
     }
 }

--- a/MyMoney.Tests/ViewModelTests/CurrencyExpressionAttributeTests.cs
+++ b/MyMoney.Tests/ViewModelTests/CurrencyExpressionAttributeTests.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+using MyMoney.ValidationAttributes;
+
+namespace MyMoney.Tests.ViewModelTests
+{
+    [TestClass]
+    public class CurrencyExpressionAttributeTests
+    {
+        [TestMethod]
+        public void GetValidationResult_AllowsValidCurrencyExpression()
+        {
+            var attribute = new CurrencyExpressionAttribute { AllowNegative = false };
+
+            var result = attribute.GetValidationResult("$1,200 / 2", CreateValidationContext());
+
+            Assert.AreEqual(ValidationResult.Success, result);
+        }
+
+        [TestMethod]
+        public void GetValidationResult_ReturnsParserErrorForInvalidExpression()
+        {
+            var attribute = new CurrencyExpressionAttribute();
+
+            var result = attribute.GetValidationResult("not currency", CreateValidationContext());
+
+            Assert.IsNotNull(result);
+            Assert.AreNotEqual(attribute.InvalidExpressionErrorMessage, result.ErrorMessage);
+        }
+
+        [TestMethod]
+        public void GetValidationResult_RejectsNegativeExpressionWhenConfigured()
+        {
+            var attribute = new CurrencyExpressionAttribute { AllowNegative = false };
+
+            var result = attribute.GetValidationResult("10 - 25", CreateValidationContext());
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(attribute.NegativeErrorMessage, result.ErrorMessage);
+        }
+
+        private static ValidationContext CreateValidationContext()
+        {
+            return new ValidationContext(new object());
+        }
+    }
+}

--- a/MyMoney.Tests/packages.lock.json
+++ b/MyMoney.Tests/packages.lock.json
@@ -416,26 +416,26 @@
       },
       "NCalc.Core": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "9O+2pY8GyqI4snOGKtQA8Vtgyv1pUSgJtauotYJxFRvHK1asUF+vkvXTX12FTUgPCoZ6h1ubZXe+fCXaRBU7+Q==",
+        "resolved": "6.3.0",
+        "contentHash": "DYhNhLVUQk5bNQBVeHoReZqFdR4WU5kptIfjIJHRRNPs7Ph+fOlxVpfwONVG1i0sBlnFQ2mEexCSXcKhfWGI2Q==",
         "dependencies": {
           "ExtendedNumerics.BigDecimal": "3003.0.0.346",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "NCalc.Parser": "6.2.0",
+          "NCalc.Parser": "6.3.0",
           "Parlot": "1.5.7"
         }
       },
       "NCalc.Domain": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "q4O09l7FR6WKH31F727gIehM5x79gNKIW4PY9ll74Dm3LpRwVBh1JiEFcVA9WRNJhy7fnBwkyVnQNuX5S6rwUQ=="
+        "resolved": "6.3.0",
+        "contentHash": "MUuFquLKiW4WwuGK4rSZEZYPxD1j6ZX21dxSpQbHfUnR7oIsV71rkhvMOb1mafQgsZrlSa9c8xBbKrlLxmOPfQ=="
       },
       "NCalc.Parser": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "Q/QdZ2xy3KHkfVvmW8ozKRWI84lo9HEje65ohKA6G+KqiwsDLN8Yr5DsNr60PSHTV186GfhPbls3zCtBKDTi3g==",
+        "resolved": "6.3.0",
+        "contentHash": "YMbau/slMZuyAJhcyF/hoa2bG7OLjLcboo13BOWOuK//DzuxM4YQtetQO4hODxkrHSdieELVfRV03Vn9bq7Sog==",
         "dependencies": {
-          "NCalc.Domain": "6.2.0",
+          "NCalc.Domain": "6.3.0",
           "Parlot": "1.5.7"
         }
       },
@@ -527,7 +527,7 @@
           "LiveChartsCore.SkiaSharpView.WPF": "[2.0.5, )",
           "Microsoft.Extensions.Hosting": "[10.0.9, )",
           "MyMoney.Core": "[1.0.0, )",
-          "NCalcSync": "[6.2.0, )",
+          "NCalcSync": "[6.3.0, )",
           "WPF-UI": "[4.3.0, )",
           "gong-wpf-dragdrop": "[4.0.0, )"
         }
@@ -537,7 +537,8 @@
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "CsvHelper": "[33.1.0, )",
-          "LiteDB": "[5.0.21, )"
+          "LiteDB": "[5.0.21, )",
+          "NCalcSync": "[6.3.0, )"
         }
       },
       "CommunityToolkit.Mvvm": {
@@ -607,11 +608,11 @@
       },
       "NCalcSync": {
         "type": "CentralTransitive",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "Pfk3DSX6yAZCT5KS6f6jps2w9wcGzjsglXky6mDNVDsGD9Dl+bapNvsKYRaA1b8CFUseS/Od9yyfxY8V1OwazQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "r02xI0zZB12Cxelz136/CxyMGNfmXWnxQUXohLaTdXxitVZafEKSaQWuabJwBVrRDCu9Cr09gAKWooplZoS5iw==",
         "dependencies": {
-          "NCalc.Core": "6.2.0"
+          "NCalc.Core": "6.3.0"
         }
       },
       "WPF-UI": {

--- a/MyMoney/Converters/FirstValidationErrorConverter.cs
+++ b/MyMoney/Converters/FirstValidationErrorConverter.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace MyMoney.Converters
+{
+    public class FirstValidationErrorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is IEnumerable errors)
+            {
+                foreach (var error in errors)
+                {
+                    if (error is ValidationError validationError)
+                    {
+                        return validationError.ErrorContent?.ToString() ?? string.Empty;
+                    }
+                }
+            }
+
+            return string.Empty;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MyMoney/ValidationAttributes/CurrencyExpressionAttribute.cs
+++ b/MyMoney/ValidationAttributes/CurrencyExpressionAttribute.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel.DataAnnotations;
+using MyMoney.Core.Services;
+
+namespace MyMoney.ValidationAttributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
+    public sealed class CurrencyExpressionAttribute : ValidationAttribute
+    {
+        public bool AllowNegative { get; set; } = true;
+
+        public string RequiredErrorMessage { get; set; } = "Amount is required.";
+
+        public string InvalidExpressionErrorMessage { get; set; } = "Enter a valid amount or math expression.";
+
+        public string NegativeErrorMessage { get; set; } = "The amount cannot be negative.";
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            var expression = value as string;
+
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return new ValidationResult(RequiredErrorMessage);
+            }
+
+            if (!CurrencyExpressionParser.TryEvaluate(
+                    expression,
+                    out decimal amount,
+                    out string? error))
+            {
+                return new ValidationResult(
+                    error ?? InvalidExpressionErrorMessage);
+            }
+
+            if (!AllowNegative && amount < 0)
+            {
+                return new ValidationResult(
+                    NegativeErrorMessage);
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
@@ -17,7 +17,7 @@ namespace MyMoney.ViewModels.ContentDialogs
         [NotifyDataErrorInfo]
         [Required(ErrorMessage = "Budget amount is required.")]
         [CurrencyExpression(AllowNegative = false)]
-        private string _budgetAmountStr = "";
+        private string _budgetAmountStr = new Currency(0m).ToString();
 
         private Currency _budgetedAmount = new Currency(0);
 

--- a/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
@@ -1,13 +1,103 @@
-﻿using MyMoney.Core.Models;
+﻿using System.ComponentModel.DataAnnotations;
+using MyMoney.Core.Models;
+using MyMoney.Core.Services;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class BudgetCategoryDialogViewModel : ObservableObject
+    public partial class BudgetCategoryDialogViewModel : ObservableValidator
     {
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Budget category is required.")]
+        [CustomValidation(typeof(BudgetCategoryDialogViewModel), nameof(ValidateBudgetCategory))]
         private string _budgetCategory = "";
 
         [ObservableProperty]
-        private Currency _budgetAmount = new(0m);
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Budget amount is required.")]
+        [CustomValidation(typeof(BudgetCategoryDialogViewModel), nameof(ValidateBudgetedAmount))]
+        private string _budgetAmountStr = "";
+
+        private Currency _budgetedAmount = new Currency(0);
+
+        public Currency BudgetAmount
+        {
+            get
+            {
+                return _budgetedAmount;
+            }
+            set
+            {
+                if (_budgetedAmount != value)
+                {
+                    _budgetedAmount = value;
+                    BudgetAmountStr = value.ToString();
+                }
+            }
+        }
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        private void FormatBudgetAmount()
+        {
+            ValidateProperty(BudgetAmountStr, nameof(BudgetAmountStr));
+
+            if (GetErrors(nameof(BudgetAmountStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            BudgetAmountStr = BudgetAmount.ToString();
+        }
+
+        partial void OnBudgetAmountStrChanged(string? oldValue, string newValue)
+        {
+            _budgetedAmount = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0);
+            FormatBudgetAmount();
+        }
+
+        public static ValidationResult? ValidateBudgetCategory(object? value, ValidationContext context)
+        {
+            var category = value as string;
+
+            if (string.IsNullOrWhiteSpace(category))
+            {
+                return new ValidationResult("Budget category is required.");
+            }
+
+            return ValidationResult.Success;
+        }
+
+        public static ValidationResult? ValidateBudgetedAmount(object? value, ValidationContext context)
+        {
+            var expression = value as string;
+
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return new ValidationResult("Amount is required.");
+            }
+
+            if (!CurrencyExpressionParser.TryEvaluate(
+                    expression,
+                    out decimal amount,
+                    out string? error))
+            {
+                return new ValidationResult(
+                    error ?? "Enter a valid amount or math expression.");
+            }
+
+            if (amount < 0)
+            {
+                return new ValidationResult(
+                    "The amount cannot be negative.");
+            }
+
+            return ValidationResult.Success;
+        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/BudgetCategoryDialogViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using MyMoney.Core.Models;
 using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
@@ -15,7 +16,7 @@ namespace MyMoney.ViewModels.ContentDialogs
         [ObservableProperty]
         [NotifyDataErrorInfo]
         [Required(ErrorMessage = "Budget amount is required.")]
-        [CustomValidation(typeof(BudgetCategoryDialogViewModel), nameof(ValidateBudgetedAmount))]
+        [CurrencyExpression(AllowNegative = false)]
         private string _budgetAmountStr = "";
 
         private Currency _budgetedAmount = new Currency(0);
@@ -73,31 +74,5 @@ namespace MyMoney.ViewModels.ContentDialogs
             return ValidationResult.Success;
         }
 
-        public static ValidationResult? ValidateBudgetedAmount(object? value, ValidationContext context)
-        {
-            var expression = value as string;
-
-            if (string.IsNullOrWhiteSpace(expression))
-            {
-                return new ValidationResult("Amount is required.");
-            }
-
-            if (!CurrencyExpressionParser.TryEvaluate(
-                    expression,
-                    out decimal amount,
-                    out string? error))
-            {
-                return new ValidationResult(
-                    error ?? "Enter a valid amount or math expression.");
-            }
-
-            if (amount < 0)
-            {
-                return new ValidationResult(
-                    "The amount cannot be negative.");
-            }
-
-            return ValidationResult.Success;
-        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/ExportTransactionsDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/ExportTransactionsDialogViewModel.cs
@@ -1,8 +1,9 @@
+using System.ComponentModel.DataAnnotations;
 using MyMoney.Core.Exports;
 
 namespace MyMoney.ViewModels.ContentDialogs;
 
-public partial class ExportTransactionsDialogViewModel : ObservableObject
+public partial class ExportTransactionsDialogViewModel : ObservableValidator
 {
     [ObservableProperty]
     private bool _exportCurrentAccount = true;
@@ -17,27 +18,43 @@ public partial class ExportTransactionsDialogViewModel : ObservableObject
     private bool _useDateRange;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateDateRange))]
     private DateTime _startDate = DateTime.Today.AddMonths(-1);
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateDateRange))]
     private DateTime _endDate = DateTime.Today;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includeAccountName = true;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includeReconciled = true;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includeDate = true;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includePayee = true;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includeCategory = true;
 
     [ObservableProperty]
+    [NotifyDataErrorInfo]
+    [CustomValidation(typeof(ExportTransactionsDialogViewModel), nameof(ValidateSelectedFields))]
     private bool _includeAmount = true;
 
     public bool HasSelectedFields =>
@@ -68,6 +85,11 @@ public partial class ExportTransactionsDialogViewModel : ObservableObject
         return fields;
     }
 
+    public void Validate()
+    {
+        ValidateAllProperties();
+    }
+
     partial void OnExportCurrentAccountChanged(bool value)
     {
         if (value)
@@ -84,18 +106,67 @@ public partial class ExportTransactionsDialogViewModel : ObservableObject
     {
         if (value)
             UseDateRange = false;
+
+        ValidateDateRangeProperties();
     }
 
     partial void OnUseDateRangeChanged(bool value)
     {
         if (value)
             ExportAllDates = false;
+
+        ValidateDateRangeProperties();
     }
 
-    partial void OnIncludeAccountNameChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
-    partial void OnIncludeReconciledChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
-    partial void OnIncludeDateChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
-    partial void OnIncludePayeeChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
-    partial void OnIncludeCategoryChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
-    partial void OnIncludeAmountChanged(bool value) => OnPropertyChanged(nameof(HasSelectedFields));
+    partial void OnStartDateChanged(DateTime value) => ValidateDateRangeProperties();
+
+    partial void OnEndDateChanged(DateTime value) => ValidateDateRangeProperties();
+
+    partial void OnIncludeAccountNameChanged(bool value) => ValidateFieldProperties();
+    partial void OnIncludeReconciledChanged(bool value) => ValidateFieldProperties();
+    partial void OnIncludeDateChanged(bool value) => ValidateFieldProperties();
+    partial void OnIncludePayeeChanged(bool value) => ValidateFieldProperties();
+    partial void OnIncludeCategoryChanged(bool value) => ValidateFieldProperties();
+    partial void OnIncludeAmountChanged(bool value) => ValidateFieldProperties();
+
+    private void ValidateDateRangeProperties()
+    {
+        ValidateProperty(StartDate, nameof(StartDate));
+        ValidateProperty(EndDate, nameof(EndDate));
+    }
+
+    private void ValidateFieldProperties()
+    {
+        OnPropertyChanged(nameof(HasSelectedFields));
+        ValidateProperty(IncludeAccountName, nameof(IncludeAccountName));
+        ValidateProperty(IncludeReconciled, nameof(IncludeReconciled));
+        ValidateProperty(IncludeDate, nameof(IncludeDate));
+        ValidateProperty(IncludePayee, nameof(IncludePayee));
+        ValidateProperty(IncludeCategory, nameof(IncludeCategory));
+        ValidateProperty(IncludeAmount, nameof(IncludeAmount));
+    }
+
+    public static ValidationResult? ValidateDateRange(object? value, ValidationContext context)
+    {
+        if (context.ObjectInstance is not ExportTransactionsDialogViewModel viewModel)
+        {
+            return ValidationResult.Success;
+        }
+
+        return viewModel.UseDateRange && viewModel.StartDate.Date > viewModel.EndDate.Date
+            ? new ValidationResult("Start date must be on or before end date.")
+            : ValidationResult.Success;
+    }
+
+    public static ValidationResult? ValidateSelectedFields(object? value, ValidationContext context)
+    {
+        if (context.ObjectInstance is not ExportTransactionsDialogViewModel viewModel)
+        {
+            return ValidationResult.Success;
+        }
+
+        return viewModel.HasSelectedFields
+            ? ValidationResult.Success
+            : new ValidationResult("Select at least one field.");
+    }
 }

--- a/MyMoney/ViewModels/ContentDialogs/NewAccountDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/NewAccountDialogViewModel.cs
@@ -1,13 +1,70 @@
-﻿using MyMoney.Core.Models;
+using System.ComponentModel.DataAnnotations;
+using MyMoney.Core.Models;
+using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class NewAccountDialogViewModel : ObservableObject
+    public partial class NewAccountDialogViewModel : ObservableValidator
     {
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Account name is required.")]
+        [CustomValidation(typeof(NewAccountDialogViewModel), nameof(ValidateAccountName))]
         private string _accountName = "";
 
         [ObservableProperty]
         private Currency _startingBalance = new(0m);
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Starting balance is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Starting balance is required.",
+            NegativeErrorMessage = "Starting balance cannot be negative.")]
+        private string _startingBalanceStr = new Currency(0m).ToString();
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        private void FormatStartingBalance()
+        {
+            ValidateProperty(StartingBalanceStr, nameof(StartingBalanceStr));
+
+            if (GetErrors(nameof(StartingBalanceStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            StartingBalanceStr = StartingBalance.ToString();
+        }
+
+        partial void OnStartingBalanceChanged(Currency value)
+        {
+            StartingBalanceStr = value.ToString();
+        }
+
+        partial void OnStartingBalanceStrChanged(string? oldValue, string newValue)
+        {
+            _startingBalance = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatStartingBalance();
+        }
+
+        public static ValidationResult? ValidateAccountName(object? value, ValidationContext context)
+        {
+            var accountName = value as string;
+
+            if (string.IsNullOrWhiteSpace(accountName))
+            {
+                return new ValidationResult("Account name is required.");
+            }
+
+            return ValidationResult.Success;
+        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/NewExpenseGroupDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/NewExpenseGroupDialogViewModel.cs
@@ -1,14 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel.DataAnnotations;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class NewExpenseGroupDialogViewModel : ObservableObject
+    public partial class NewExpenseGroupDialogViewModel : ObservableValidator
     {
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Group name is required.")]
+        [CustomValidation(typeof(NewExpenseGroupDialogViewModel), nameof(ValidateGroupName))]
         private string _groupName = string.Empty;
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        public static ValidationResult? ValidateGroupName(object? value, ValidationContext context)
+        {
+            var groupName = value as string;
+
+            if (string.IsNullOrWhiteSpace(groupName))
+            {
+                return new ValidationResult("Group name is required.");
+            }
+
+            return ValidationResult.Success;
+        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/NewTransactionDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/NewTransactionDialogViewModel.cs
@@ -1,12 +1,15 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Windows.Data;
 using MyMoney.Core.Database;
 using MyMoney.Core.Models;
+using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class NewTransactionDialogViewModel : ObservableObject
+    public partial class NewTransactionDialogViewModel : ObservableValidator
     {
         private readonly IDatabaseManager _databaseManager;
 
@@ -14,12 +17,22 @@ namespace MyMoney.ViewModels.ContentDialogs
         private DateTime _newTransactionDate = DateTime.Today;
 
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Transaction date is required.")]
+        private DateTime? _newTransactionDateInput = DateTime.Today;
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Payee is required.")]
+        [CustomValidation(typeof(NewTransactionDialogViewModel), nameof(ValidatePayee))]
         private string _newTransactionPayee = "";
 
         [ObservableProperty]
         private Category _newTransactionCategory = new();
 
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [CustomValidation(typeof(NewTransactionDialogViewModel), nameof(ValidateCategorySelectedIndex))]
         private int _newTransactionCategorySelectedIndex = -1;
 
         [ObservableProperty]
@@ -27,6 +40,15 @@ namespace MyMoney.ViewModels.ContentDialogs
 
         [ObservableProperty]
         private Currency _newTransactionAmount = new(0m);
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Transaction amount is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Transaction amount is required.",
+            NegativeErrorMessage = "Transaction amount cannot be negative.")]
+        private string _newTransactionAmountStr = new Currency(0m).ToString();
 
         [ObservableProperty]
         private bool _newTransactionIsExpense = true;
@@ -45,6 +67,11 @@ namespace MyMoney.ViewModels.ContentDialogs
         public NewTransactionDialogViewModel(IDatabaseManager databaseManager)
         {
             _databaseManager = databaseManager ?? throw new ArgumentNullException(nameof(databaseManager));
+        }
+
+        public void Validate()
+        {
+            ValidateAllProperties();
         }
 
         public void SetCategoryNames(ObservableCollection<Category> categories)
@@ -68,6 +95,8 @@ namespace MyMoney.ViewModels.ContentDialogs
 
         partial void OnNewTransactionDateChanged(DateTime oldValue, DateTime newValue)
         {
+            NewTransactionDateInput = newValue;
+
             if (oldValue.Month == newValue.Month && oldValue.Year == newValue.Year)
                 return;
 
@@ -81,6 +110,29 @@ namespace MyMoney.ViewModels.ContentDialogs
             }
 
             SetSelectedCategoryByName(selectedCategory);
+        }
+
+        partial void OnNewTransactionDateInputChanged(DateTime? oldValue, DateTime? newValue)
+        {
+            if (newValue is not { } date)
+            {
+                return;
+            }
+
+            NewTransactionDate = date;
+        }
+
+        partial void OnNewTransactionAmountChanged(Currency value)
+        {
+            NewTransactionAmountStr = value.ToString();
+        }
+
+        partial void OnNewTransactionAmountStrChanged(string? oldValue, string newValue)
+        {
+            _newTransactionAmount = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatNewTransactionAmount();
         }
 
         public ObservableCollection<Category> GetBudgetCategoryNames()
@@ -125,6 +177,40 @@ namespace MyMoney.ViewModels.ContentDialogs
             {
                 collection.Add(new Category { Group = group, Name = item });
             }
+        }
+
+        private void FormatNewTransactionAmount()
+        {
+            ValidateProperty(NewTransactionAmountStr, nameof(NewTransactionAmountStr));
+
+            if (GetErrors(nameof(NewTransactionAmountStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            NewTransactionAmountStr = NewTransactionAmount.ToString();
+        }
+
+        public static ValidationResult? ValidatePayee(object? value, ValidationContext context)
+        {
+            var payee = value as string;
+
+            if (string.IsNullOrWhiteSpace(payee))
+            {
+                return new ValidationResult("Payee is required.");
+            }
+
+            return ValidationResult.Success;
+        }
+
+        public static ValidationResult? ValidateCategorySelectedIndex(object? value, ValidationContext context)
+        {
+            if (value is not int selectedIndex || selectedIndex < 0)
+            {
+                return new ValidationResult("Category is required.");
+            }
+
+            return ValidationResult.Success;
         }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/RenameAccountViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/RenameAccountViewModel.cs
@@ -1,8 +1,30 @@
-﻿namespace MyMoney.ViewModels.ContentDialogs
+using System.ComponentModel.DataAnnotations;
+
+namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class RenameAccountViewModel : ObservableObject
+    public partial class RenameAccountViewModel : ObservableValidator
     {
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Account name is required.")]
+        [CustomValidation(typeof(RenameAccountViewModel), nameof(ValidateNewName))]
         private string _newName = string.Empty;
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        public static ValidationResult? ValidateNewName(object? value, ValidationContext context)
+        {
+            var name = value as string;
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return new ValidationResult("Account name is required.");
+            }
+
+            return ValidationResult.Success;
+        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/SavingsCategoryDialogViewModel.cs
@@ -1,19 +1,43 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using MyMoney.Core.Models;
+using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class SavingsCategoryDialogViewModel : ObservableObject
+    public partial class SavingsCategoryDialogViewModel : ObservableValidator
     {
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Savings category is required.")]
+        [CustomValidation(typeof(SavingsCategoryDialogViewModel), nameof(ValidateSavingsCategory))]
         private string _category = string.Empty;
 
         [ObservableProperty]
         private Currency _planned = new(0m);
 
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Planned amount is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Planned amount is required.",
+            NegativeErrorMessage = "Planned amount cannot be negative.")]
+        private string _plannedStr = new Currency(0m).ToString();
+
+        [ObservableProperty]
         private Currency _currentBalance = new(0m);
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Current balance is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Current balance is required.",
+            NegativeErrorMessage = "Current balance cannot be negative.")]
+        private string _currentBalanceStr = new Currency(0m).ToString();
 
         [ObservableProperty]
         private ObservableCollection<Transaction> _recentTransactions = [];
@@ -26,6 +50,11 @@ namespace MyMoney.ViewModels.ContentDialogs
 
         [ObservableProperty]
         private GridLength _editColumnWidth = new(200, GridUnitType.Pixel);
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
 
         public void SortTransactions()
         {
@@ -53,6 +82,68 @@ namespace MyMoney.ViewModels.ContentDialogs
                     EditColumnWidth = new(200, GridUnitType.Pixel);
                 }
             }
+        }
+
+        private void FormatPlanned()
+        {
+            ValidateProperty(PlannedStr, nameof(PlannedStr));
+
+            if (GetErrors(nameof(PlannedStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            PlannedStr = Planned.ToString();
+        }
+
+        private void FormatCurrentBalance()
+        {
+            ValidateProperty(CurrentBalanceStr, nameof(CurrentBalanceStr));
+
+            if (GetErrors(nameof(CurrentBalanceStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            CurrentBalanceStr = CurrentBalance.ToString();
+        }
+
+        partial void OnPlannedChanged(Currency value)
+        {
+            PlannedStr = value.ToString();
+        }
+
+        partial void OnPlannedStrChanged(string? oldValue, string newValue)
+        {
+            _planned = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatPlanned();
+        }
+
+        partial void OnCurrentBalanceChanged(Currency value)
+        {
+            CurrentBalanceStr = value.ToString();
+        }
+
+        partial void OnCurrentBalanceStrChanged(string? oldValue, string newValue)
+        {
+            _currentBalance = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatCurrentBalance();
+        }
+
+        public static ValidationResult? ValidateSavingsCategory(object? value, ValidationContext context)
+        {
+            var category = value as string;
+
+            if (string.IsNullOrWhiteSpace(category))
+            {
+                return new ValidationResult("Savings category is required.");
+            }
+
+            return ValidationResult.Success;
         }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/TransferDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/TransferDialogViewModel.cs
@@ -1,19 +1,111 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
 using MyMoney.Core.Models;
+using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class TransferDialogViewModel(ObservableCollection<string> accountNames) : ObservableObject
+    public partial class TransferDialogViewModel(ObservableCollection<string> accountNames) : ObservableValidator
     {
         public ObservableCollection<string> Accounts { get; } = accountNames;
 
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Transfer from account is required.")]
+        [CustomValidation(typeof(TransferDialogViewModel), nameof(ValidateTransferFrom))]
         private string _transferFrom = "";
 
         [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Transfer to account is required.")]
+        [CustomValidation(typeof(TransferDialogViewModel), nameof(ValidateTransferTo))]
         private string _transferTo = "";
 
         [ObservableProperty]
         private Currency _amount = new(0m);
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Transfer amount is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Transfer amount is required.",
+            NegativeErrorMessage = "Transfer amount cannot be negative.")]
+        private string _amountStr = new Currency(0m).ToString();
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        private void FormatAmount()
+        {
+            ValidateProperty(AmountStr, nameof(AmountStr));
+
+            if (GetErrors(nameof(AmountStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            AmountStr = Amount.ToString();
+        }
+
+        partial void OnTransferFromChanged(string? oldValue, string newValue)
+        {
+            ValidateProperty(TransferTo, nameof(TransferTo));
+        }
+
+        partial void OnTransferToChanged(string? oldValue, string newValue)
+        {
+            ValidateProperty(TransferFrom, nameof(TransferFrom));
+        }
+
+        partial void OnAmountChanged(Currency value)
+        {
+            AmountStr = value.ToString();
+        }
+
+        partial void OnAmountStrChanged(string? oldValue, string newValue)
+        {
+            _amount = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatAmount();
+        }
+
+        public static ValidationResult? ValidateTransferFrom(object? value, ValidationContext context)
+        {
+            var transferFrom = value as string;
+
+            if (string.IsNullOrWhiteSpace(transferFrom))
+            {
+                return new ValidationResult("Transfer from account is required.");
+            }
+
+            if (context.ObjectInstance is TransferDialogViewModel vm && transferFrom == vm.TransferTo)
+            {
+                return new ValidationResult("Transfer accounts must be different.");
+            }
+
+            return ValidationResult.Success;
+        }
+
+        public static ValidationResult? ValidateTransferTo(object? value, ValidationContext context)
+        {
+            var transferTo = value as string;
+
+            if (string.IsNullOrWhiteSpace(transferTo))
+            {
+                return new ValidationResult("Transfer to account is required.");
+            }
+
+            if (context.ObjectInstance is TransferDialogViewModel vm && transferTo == vm.TransferFrom)
+            {
+                return new ValidationResult("Transfer accounts must be different.");
+            }
+
+            return ValidationResult.Success;
+        }
     }
 }

--- a/MyMoney/ViewModels/ContentDialogs/UpdateAccountBalanceDialogViewModel.cs
+++ b/MyMoney/ViewModels/ContentDialogs/UpdateAccountBalanceDialogViewModel.cs
@@ -1,10 +1,52 @@
-﻿using MyMoney.Core.Models;
+using System.ComponentModel.DataAnnotations;
+using MyMoney.Core.Models;
+using MyMoney.Core.Services;
+using MyMoney.ValidationAttributes;
 
 namespace MyMoney.ViewModels.ContentDialogs
 {
-    public partial class UpdateAccountBalanceDialogViewModel : ObservableObject
+    public partial class UpdateAccountBalanceDialogViewModel : ObservableValidator
     {
         [ObservableProperty]
         private Currency _balance = new(0m);
+
+        [ObservableProperty]
+        [NotifyDataErrorInfo]
+        [Required(ErrorMessage = "Balance is required.")]
+        [CurrencyExpression(
+            AllowNegative = false,
+            RequiredErrorMessage = "Balance is required.",
+            NegativeErrorMessage = "Balance cannot be negative.")]
+        private string _balanceStr = "";
+
+        public void Validate()
+        {
+            ValidateAllProperties();
+        }
+
+        private void FormatBalance()
+        {
+            ValidateProperty(BalanceStr, nameof(BalanceStr));
+
+            if (GetErrors(nameof(BalanceStr)).Cast<object>().Any())
+            {
+                return;
+            }
+
+            BalanceStr = Balance.ToString();
+        }
+
+        partial void OnBalanceChanged(Currency value)
+        {
+            BalanceStr = value.ToString();
+        }
+
+        partial void OnBalanceStrChanged(string? oldValue, string newValue)
+        {
+            _balance = CurrencyExpressionParser.TryEvaluate(newValue, out decimal amount, out _)
+                ? new Currency(amount)
+                : new Currency(0m);
+            FormatBalance();
+        }
     }
 }

--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
@@ -15,7 +15,9 @@
     Closing="ContentDialog_Closing"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
         <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:BudgetCategoryDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
@@ -23,9 +25,14 @@
         <ui:TextBox
             x:Name="TxtCategory"
             MinWidth="300"
-            Margin="1,4,2,8"
+            Margin="1,4,2,1"
             GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
             Text="{Binding BudgetCategory, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,8"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=TxtCategory, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=TxtCategory, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
         <Label Margin="0,8,0,4">Amount</Label>
         <ui:TextBox
@@ -34,5 +41,10 @@
             GotKeyboardFocus="txtAmount_GotKeyboardFocus"
             KeyDown="txtAmount_KeyDown"
             Text="{Binding BudgetAmountStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtAmount, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtAmount, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml
@@ -20,26 +20,19 @@
     </ui:ContentDialog.Resources>
     <StackPanel>
         <Label Margin="0,0,0,4">Category</Label>
-        <Border
-            x:Name="TxtCategoryBorder"
-            Margin="0,4,0,8"
-            BorderBrush="Transparent"
-            BorderThickness="1">
-            <ui:TextBox
-                x:Name="TxtCategory"
-                MinWidth="300"
-                GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
-                LostKeyboardFocus="TxtCategory_LostKeyboardFocus"
-                LostMouseCapture="TxtCategory_LostMouseCapture"
-                Text="{Binding BudgetCategory}" />
-        </Border>
+        <ui:TextBox
+            x:Name="TxtCategory"
+            MinWidth="300"
+            Margin="1,4,2,8"
+            GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
+            Text="{Binding BudgetCategory, ValidatesOnNotifyDataErrors=True}" />
 
         <Label Margin="0,8,0,4">Amount</Label>
         <ui:TextBox
             x:Name="txtAmount"
-            Margin="1,4,1,0"
+            Margin="1,4,2,1"
             GotKeyboardFocus="txtAmount_GotKeyboardFocus"
             KeyDown="txtAmount_KeyDown"
-            Text="{Binding Path=BudgetAmount, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding BudgetAmountStr, ValidatesOnNotifyDataErrors=True}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/BudgetCategoryDialog.xaml.cs
@@ -45,31 +45,15 @@ namespace MyMoney.Views.ContentDialogs
             TxtCategory.Focus();
             TxtCategory.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
-            var amountValidationErrors = Validation.GetErrors(txtAmount);
+            if (DataContext is BudgetCategoryDialogViewModel vm)
+            {
+                vm.Validate();
 
-            if (!string.IsNullOrWhiteSpace(TxtCategory.Text) && amountValidationErrors is not { Count: > 0 })
-                return;
-            args.Cancel = true;
-
-            ValidateTxtCategory();
-        }
-
-        private void ValidateTxtCategory()
-        {
-            if (string.IsNullOrWhiteSpace(TxtCategory.Text))
-                TxtCategoryBorder.BorderBrush = new SolidColorBrush(Colors.Red);
-            else
-                TxtCategoryBorder.BorderBrush = new SolidColorBrush(Colors.Transparent);
-        }
-
-        private void TxtCategory_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
-        {
-            ValidateTxtCategory();
-        }
-
-        private void TxtCategory_LostMouseCapture(object sender, MouseEventArgs e)
-        {
-            ValidateTxtCategory();
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
+            }
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs"
+    xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -18,6 +19,8 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:ExportTransactionsDialog}" />
     </ui:ContentDialog.Resources>
 
@@ -51,32 +54,38 @@
             </Grid.ColumnDefinitions>
             <DatePicker SelectedDate="{Binding StartDate}" SelectedDateFormat="Short" />
             <DatePicker
+                x:Name="EndDatePicker"
                 Grid.Column="2"
-                SelectedDate="{Binding EndDate}"
+                SelectedDate="{Binding EndDate, ValidatesOnNotifyDataErrors=True}"
                 SelectedDateFormat="Short" />
         </Grid>
+        <TextBlock
+            Margin="1,-12,2,12"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=EndDatePicker, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=EndDatePicker, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
         <ui:TextBlock Margin="0,0,0,8">Fields to include</ui:TextBlock>
         <Border
-            x:Name="FieldsBorder"
             Margin="0,0,0,8"
             Padding="8"
             BorderBrush="Transparent"
             BorderThickness="1"
             CornerRadius="8">
             <UniformGrid Columns="2" Rows="3">
-                <CheckBox IsChecked="{Binding IncludeAccountName}">Account name</CheckBox>
-                <CheckBox IsChecked="{Binding IncludeReconciled}">Reconciled</CheckBox>
-                <CheckBox IsChecked="{Binding IncludeDate}">Date</CheckBox>
-                <CheckBox IsChecked="{Binding IncludePayee}">Payee</CheckBox>
-                <CheckBox IsChecked="{Binding IncludeCategory}">Category</CheckBox>
-                <CheckBox IsChecked="{Binding IncludeAmount}">Amount</CheckBox>
+                <CheckBox x:Name="IncludeAccountNameCheckBox" IsChecked="{Binding IncludeAccountName, ValidatesOnNotifyDataErrors=True}">Account name</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeReconciled, ValidatesOnNotifyDataErrors=True}">Reconciled</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeDate, ValidatesOnNotifyDataErrors=True}">Date</CheckBox>
+                <CheckBox IsChecked="{Binding IncludePayee, ValidatesOnNotifyDataErrors=True}">Payee</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeCategory, ValidatesOnNotifyDataErrors=True}">Category</CheckBox>
+                <CheckBox IsChecked="{Binding IncludeAmount, ValidatesOnNotifyDataErrors=True}">Amount</CheckBox>
             </UniformGrid>
         </Border>
 
         <TextBlock
-            x:Name="ValidationText"
-            Foreground="Red"
-            Visibility="Collapsed" />
+            Margin="1,-4,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=IncludeAccountNameCheckBox, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=IncludeAccountNameCheckBox, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/ExportTransactionsDialog.xaml.cs
@@ -1,5 +1,3 @@
-using System.Windows;
-using System.Windows.Media;
 using MyMoney.Abstractions;
 using MyMoney.ViewModels.ContentDialogs;
 using Wpf.Ui.Controls;
@@ -21,24 +19,11 @@ public partial class ExportTransactionsDialog : ContentDialog, IContentDialog
         if (DataContext is not ExportTransactionsDialogViewModel viewModel)
             return;
 
-        var hasError = false;
-        ValidationText.Visibility = Visibility.Collapsed;
-        FieldsBorder.BorderBrush = Brushes.Transparent;
+        viewModel.Validate();
 
-        if (!viewModel.HasSelectedFields)
+        if (viewModel.HasErrors)
         {
-            hasError = true;
-            FieldsBorder.BorderBrush = Brushes.Red;
-            ValidationText.Text = "Select at least one field.";
-            ValidationText.Visibility = Visibility.Visible;
+            args.Cancel = true;
         }
-        else if (viewModel.UseDateRange && viewModel.StartDate.Date > viewModel.EndDate.Date)
-        {
-            hasError = true;
-            ValidationText.Text = "Start date must be on or before end date.";
-            ValidationText.Visibility = Visibility.Visible;
-        }
-
-        args.Cancel = hasError;
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml
@@ -15,7 +15,8 @@
     Closing="ContentDialog_Closing"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
-        <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewAccountDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
@@ -23,15 +24,26 @@
         <ui:TextBox
             x:Name="TxtAccountName"
             MinWidth="300"
-            Margin="0,4,0,8"
+            Margin="1,4,2,1"
             GotFocus="TxtAccountName_GotFocus"
-            Text="{Binding AccountName}" />
+            Text="{Binding AccountName, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,8"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=TxtAccountName, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=TxtAccountName, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
+
         <Label Margin="0,8,0,4">Starting balance</Label>
         <ui:TextBox
             x:Name="txtStartingBalance"
-            Margin="0,4,0,0"
+            Margin="1,4,2,1"
             GotKeyboardFocus="txtStartingBalance_GotFocus"
             KeyDown="txtStartingBalance_KeyDown"
-            Text="{Binding StartingBalance, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding StartingBalanceStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtStartingBalance, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtStartingBalance, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewAccountDialog.xaml.cs
@@ -42,8 +42,21 @@ namespace MyMoney.Views.ContentDialogs
 
         private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
+            if (args.Result != ContentDialogResult.Primary)
+                return;
+
             TxtAccountName.Focus();
             TxtAccountName.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+
+            if (DataContext is NewAccountDialogViewModel vm)
+            {
+                vm.Validate();
+
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
+            }
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs"
+    xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -11,18 +12,27 @@
     d:DataContext="{d:DesignInstance Type=contentdialogs:NewExpenseGroupDialogViewModel}"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    Closing="ContentDialog_Closing"
     Loaded="ContentDialog_Loaded"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewExpenseGroupDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
         <TextBlock Margin="0,0,0,8">Group name</TextBlock>
         <TextBox
             x:Name="txtGroupName"
+            Margin="1,0,2,0"
             HorizontalAlignment="Stretch"
             GotKeyboardFocus="txtGroupName_GotKeyboardFocus"
             KeyDown="txtGroupName_KeyDown"
-            Text="{Binding GroupName}" />
+            Text="{Binding GroupName, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtGroupName, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtGroupName, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewExpenseGroupDialog.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using MyMoney.Abstractions;
 using MyMoney.ViewModels.ContentDialogs;
 using Wpf.Ui.Controls;
@@ -46,6 +33,25 @@ namespace MyMoney.Views.ContentDialogs
         {
             txtGroupName.Focus();
             txtGroupName.SelectAll();
+        }
+
+        private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        {
+            if (args.Result != ContentDialogResult.Primary)
+                return;
+
+            txtGroupName.Focus();
+            txtGroupName.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
+
+            if (DataContext is NewExpenseGroupDialogViewModel vm)
+            {
+                vm.Validate();
+
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
+            }
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -89,7 +89,7 @@
                 Margin="3,0,0,0"
                 MinWidth="300"
                 OriginalItemsSource="{Binding AutoSuggestPayees, Mode=OneWay}"
-                Text="{Binding NewTransactionPayee, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                Text="{Binding NewTransactionPayee, Mode=TwoWay, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
                 <ui:AutoSuggestBox.Icon>
                     <ui:FontIcon Glyph="" />
                 </ui:AutoSuggestBox.Icon>

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml
@@ -24,7 +24,8 @@
     Loaded="ContentDialog_Loaded"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
-        <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:NewTransactionDialog}" />
     </ui:ContentDialog.Resources>
 
@@ -41,15 +42,21 @@
         <ui:TextBlock Margin="0,0,0,4">Amount</ui:TextBlock>
         <ui:TextBox
             x:Name="txtAmount"
-            Margin="0,0,0,16"
+            Margin="1,0,2,0"
             GotKeyboardFocus="txtAmount_GotKeyboardFocus"
-            Text="{Binding Path=NewTransactionAmount, Converter={StaticResource CurrencyConverter}}" />
-        <Grid Margin="0,0,0,16">
+            Text="{Binding NewTransactionAmountStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtAmount, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtAmount, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
+        <Grid Margin="0,16,0,16">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="135" />
                 <ColumnDefinition />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -60,63 +67,71 @@
                 Grid.Row="1"
                 Margin="0,0,4,0"
                 IsTodayHighlighted="True"
-                SelectedDate="{Binding NewTransactionDate}"
+                SelectedDate="{Binding NewTransactionDateInput, ValidatesOnNotifyDataErrors=True}"
                 SelectedDateFormat="Short" />
+            <TextBlock
+                Grid.Row="2"
+                Margin="1,2,2,0"
+                TextWrapping="Wrap"
+                Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                Text="{Binding ElementName=txtDate, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+                Visibility="{Binding ElementName=txtDate, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
             <ui:TextBlock
                 Grid.Row="0"
                 Grid.Column="1"
                 Margin="4,0,0,4">
                 Payee
             </ui:TextBlock>
-            <Border
-                x:Name="PayeeBorder"
+            <ui:AutoSuggestBox
+                x:Name="txtPayee"
                 Grid.Row="1"
                 Grid.Column="1"
                 Margin="3,0,0,0"
-                BorderBrush="Transparent"
-                BorderThickness="1">
-                <ui:AutoSuggestBox
-                    x:Name="txtPayee"
-                    MinWidth="300"
-                    LostFocus="TxtPayee_OnLostFocus"
-                    OriginalItemsSource="{Binding AutoSuggestPayees, Mode=OneWay}">
-                    <ui:AutoSuggestBox.Icon>
-                        <ui:FontIcon Glyph="" />
-                    </ui:AutoSuggestBox.Icon>
-                </ui:AutoSuggestBox>
-            </Border>
+                MinWidth="300"
+                OriginalItemsSource="{Binding AutoSuggestPayees, Mode=OneWay}"
+                Text="{Binding NewTransactionPayee, ValidatesOnNotifyDataErrors=True, UpdateSourceTrigger=PropertyChanged}">
+                <ui:AutoSuggestBox.Icon>
+                    <ui:FontIcon Glyph="" />
+                </ui:AutoSuggestBox.Icon>
+            </ui:AutoSuggestBox>
+            <TextBlock
+                Grid.Row="2"
+                Grid.Column="1"
+                Margin="4,2,2,0"
+                Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                Text="{Binding ElementName=txtPayee, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+                Visibility="{Binding ElementName=txtPayee, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
         </Grid>
         <ui:TextBlock Margin="0,0,0,4">Category</ui:TextBlock>
 
-        <Border
-            x:Name="CategoryBorder"
-            Margin="0,0,0,16"
-            BorderBrush="Transparent"
-            BorderThickness="1">
-            <ComboBox
-                x:Name="cmbCategory"
-                DisplayMemberPath="Name"
-                ItemsSource="{Binding CategoriesView}"
-                LostFocus="cmbCategory_LostFocus"
-                SelectedIndex="{Binding NewTransactionCategorySelectedIndex}"
-                SelectedItem="{Binding NewTransactionCategory}">
-                <ComboBox.GroupStyle>
-                    <GroupStyle>
-                        <GroupStyle.HeaderTemplate>
-                            <DataTemplate>
-                                <ui:TextBlock
-                                    Margin="4,0,4,0"
-                                    FontWeight="Bold"
-                                    Foreground="{DynamicResource AccentTextFillColorTertiaryBrush}"
-                                    Text="{Binding Name}" />
-                            </DataTemplate>
-                        </GroupStyle.HeaderTemplate>
-                    </GroupStyle>
-                </ComboBox.GroupStyle>
-            </ComboBox>
-        </Border>
+        <ComboBox
+            x:Name="cmbCategory"
+            Margin="1,0,2,0"
+            DisplayMemberPath="Name"
+            ItemsSource="{Binding CategoriesView}"
+            SelectedIndex="{Binding NewTransactionCategorySelectedIndex, ValidatesOnNotifyDataErrors=True}"
+            SelectedItem="{Binding NewTransactionCategory}">
+            <ComboBox.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate>
+                            <ui:TextBlock
+                                Margin="4,0,4,0"
+                                FontWeight="Bold"
+                                Foreground="{DynamicResource AccentTextFillColorTertiaryBrush}"
+                                Text="{Binding Name}" />
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ComboBox.GroupStyle>
+        </ComboBox>
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=cmbCategory, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=cmbCategory, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-        <ui:TextBlock Margin="0,0,0,4">Memo</ui:TextBlock>
+        <ui:TextBlock Margin="0,16,0,4">Memo</ui:TextBlock>
         <ui:TextBox
             x:Name="txtMemo"
             Margin="0,0,0,24"

--- a/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/NewTransactionDialog.xaml.cs
@@ -1,21 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using MyMoney.Abstractions;
-using MyMoney.Core.Models;
 using MyMoney.ViewModels.ContentDialogs;
-using MyMoney.ViewModels.Pages;
 using Wpf.Ui.Controls;
 
 namespace MyMoney.Views.ContentDialogs
@@ -30,33 +15,10 @@ namespace MyMoney.Views.ContentDialogs
             InitializeComponent();
         }
 
-        public new async Task<ContentDialogResult> ShowAsync(CancellationToken cancellationToken = default)
-        {
-            if (DataContext is NewTransactionDialogViewModel viewModel)
-            {
-                txtPayee.Text = viewModel.NewTransactionPayee;
-                cmbCategory.ItemsSource = viewModel.CategoryNames;
-            }
-
-            var result = await base.ShowAsync(cancellationToken);
-
-            if (DataContext is NewTransactionDialogViewModel vm)
-            {
-                vm.NewTransactionPayee = SelectedPayee;
-            }
-
-            return result;
-        }
-
-        private async void ContentDialog_Loaded(object sender, RoutedEventArgs e)
+        private void ContentDialog_Loaded(object sender, RoutedEventArgs e)
         {
             txtAmount.Focus();
             txtAmount.SelectAll();
-        }
-
-        public string SelectedPayee
-        {
-            get { return txtPayee.Text; }
         }
 
         private void TextBox_KeyDown(object sender, KeyEventArgs e)
@@ -87,49 +49,14 @@ namespace MyMoney.Views.ContentDialogs
             txtPayee.Focus();
             txtPayee.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
-            // validate the user data, and if it is invalid, prevent the dialog from closing
-
-            // get validation errors for all the required fields
-            var amountValidationErrors = Validation.GetErrors(txtAmount);
-            var dateValidationErrors = Validation.GetErrors(txtDate);
-            var invalidPayee = txtPayee.Text == "";
-            var invalidCategory = cmbCategory.SelectedIndex == -1;
-
-            // Clear the red border from custom validated controls
-            CategoryBorder.BorderBrush = Brushes.Transparent;
-            PayeeBorder.BorderBrush = Brushes.Transparent;
-
-            // validate
-            if (
-                !invalidPayee
-                && !invalidCategory
-                && amountValidationErrors is not { Count: > 0 }
-                && dateValidationErrors is not { Count: > 0 }
-            )
-                return;
-            args.Cancel = true;
-
-            if (invalidCategory)
-                CategoryBorder.BorderBrush = Brushes.Red;
-            if (invalidPayee)
-                PayeeBorder.BorderBrush = Brushes.Red;
-        }
-
-        private void TxtPayee_OnLostFocus(object sender, RoutedEventArgs e)
-        {
-            PayeeBorder.BorderBrush = string.IsNullOrEmpty(txtPayee.Text) ? Brushes.Red : Brushes.Transparent;
-        }
-
-        private void cmbCategory_LostFocus(object sender, RoutedEventArgs e)
-        {
-            // Validate
-            if (cmbCategory.SelectedIndex == -1 && !cmbCategory.IsDropDownOpen)
+            if (DataContext is NewTransactionDialogViewModel vm)
             {
-                CategoryBorder.BorderBrush = Brushes.Red;
-            }
-            else
-            {
-                CategoryBorder.BorderBrush = Brushes.Transparent;
+                vm.Validate();
+
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
             }
         }
     }

--- a/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:contentdialogs="clr-namespace:MyMoney.ViewModels.ContentDialogs"
+    xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:MyMoney.Views.ContentDialogs"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,17 +14,26 @@
     d:DesignWidth="600"
     ui:Design.Background="{ui:ThemeResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
+    Closing="ContentDialog_Closing"
     Loaded="ContentDialog_Loaded"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:RenameAccountDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
         <TextBlock Margin="0,0,0,8">Rename account to</TextBlock>
         <TextBox
             x:Name="txtNewName"
+            Margin="1,0,2,0"
             HorizontalAlignment="Stretch"
             KeyDown="txtNewName_KeyDown"
-            Text="{Binding NewName}" />
+            Text="{Binding NewName, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtNewName, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtNewName, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/RenameAccountDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using MyMoney.Abstractions;
+using MyMoney.Abstractions;
+using MyMoney.ViewModels.ContentDialogs;
 using Wpf.Ui.Controls;
 
 namespace MyMoney.Views.ContentDialogs
@@ -27,6 +28,27 @@ namespace MyMoney.Views.ContentDialogs
                     new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next)
                 );
                 e.Handled = false;
+            }
+        }
+
+        private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
+        {
+            if (args.Result != ContentDialogResult.Primary)
+                return;
+
+            txtNewName.Focus();
+            txtNewName.MoveFocus(
+                new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next)
+            );
+
+            if (DataContext is RenameAccountViewModel vm)
+            {
+                vm.Validate();
+
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
             }
         }
     }

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml
@@ -19,7 +19,8 @@
     DialogMaxWidth="600"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
-        <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <converters:StartsWithPlusConverter x:Key="StartsWithPlusConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:SavingsCategoryDialog}" />
     </ui:ContentDialog.Resources>
@@ -35,38 +36,53 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
         <ui:TextBlock>Category</ui:TextBlock>
-        <Border
-            x:Name="TxtCategoryBorder"
+        <ui:TextBox
+            x:Name="TxtCategory"
             Grid.Row="1"
-            Margin="0,8,0,0"
-            BorderBrush="Transparent"
-            BorderThickness="1">
-            <ui:TextBox
-                x:Name="TxtCategory"
-                GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
-                LostFocus="TxtCategory_LostFocus"
-                Text="{Binding Category}" />
-        </Border>
+            Margin="1,8,1,0"
+            GotKeyboardFocus="TxtCategory_GotKeyboardFocus"
+            Text="{Binding Category, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Grid.Row="2"
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=TxtCategory, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=TxtCategory, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-        <ui:TextBlock Grid.Row="2" Margin="0,12,0,0">Planned for this month</ui:TextBlock>
+        <ui:TextBlock Grid.Row="3" Margin="0,12,0,0">Planned for this month</ui:TextBlock>
         <ui:TextBox
             x:Name="TxtPlanned"
-            Grid.Row="3"
+            Grid.Row="4"
             Margin="1,8,1,0"
             GotKeyboardFocus="TxtPlanned_GotKeyboardFocus"
-            Text="{Binding Planned, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding PlannedStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Grid.Row="5"
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=TxtPlanned, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=TxtPlanned, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
-        <ui:TextBlock Grid.Row="4" Margin="0,12,0,0">Current balance</ui:TextBlock>
+        <ui:TextBlock Grid.Row="6" Margin="0,12,0,0">Current balance</ui:TextBlock>
         <ui:TextBox
             x:Name="TxtBalance"
-            Grid.Row="5"
+            Grid.Row="7"
             Margin="1,8,1,0"
             GotKeyboardFocus="TxtBalance_GotKeyboardFocus"
-            Text="{Binding CurrentBalance, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding CurrentBalanceStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Grid.Row="8"
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=TxtBalance, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=TxtBalance, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
         <ui:TextBlock
             Grid.Column="1"
             Margin="24,0,0,0"
@@ -75,7 +91,7 @@
         </ui:TextBlock>
         <Border
             Grid.Row="1"
-            Grid.RowSpan="6"
+            Grid.RowSpan="8"
             Grid.Column="1"
             MinWidth="300"
             Margin="24,12,0,0"

--- a/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/SavingsCategoryDialog.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using MyMoney.Abstractions;
 using MyMoney.ViewModels.ContentDialogs;
 using Wpf.Ui.Controls;
@@ -10,7 +8,7 @@ namespace MyMoney.Views.ContentDialogs
     /// <summary>
     /// Interaction logic for SavingsCategoryDialog.xaml
     /// </summary>
-    public partial class SavingsCategoryDialog : Wpf.Ui.Controls.ContentDialog, IContentDialog
+    public partial class SavingsCategoryDialog : ContentDialog, IContentDialog
     {
         public SavingsCategoryDialog()
         {
@@ -33,10 +31,7 @@ namespace MyMoney.Views.ContentDialogs
             TxtBalance.SelectAll();
         }
 
-        private void ContentDialog_Closing(
-            Wpf.Ui.Controls.ContentDialog sender,
-            Wpf.Ui.Controls.ContentDialogClosingEventArgs args
-        )
+        private void ContentDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             if (args.Result != ContentDialogResult.Primary)
                 return;
@@ -44,32 +39,15 @@ namespace MyMoney.Views.ContentDialogs
             TxtCategory.Focus();
             TxtCategory.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
-            // validate the user data, and if it is invalid, prevent the dialog from closing
+            if (DataContext is SavingsCategoryDialogViewModel vm)
+            {
+                vm.Validate();
 
-            // get validation errors for all the required fields
-            var plannedValidationErrors = Validation.GetErrors(TxtPlanned);
-            var balanceValidationErrors = Validation.GetErrors(TxtBalance);
-            var invalidCategory = string.IsNullOrEmpty(TxtCategory.Text);
-
-            // Clear the red border from custom validated controls
-            TxtCategoryBorder.BorderBrush = Brushes.Transparent;
-
-            // validate
-            if (
-                !invalidCategory
-                && plannedValidationErrors is not { Count: > 0 }
-                && balanceValidationErrors is not { Count: > 0 }
-            )
-                return;
-            args.Cancel = true;
-
-            if (invalidCategory)
-                TxtCategoryBorder.BorderBrush = Brushes.Red;
-        }
-
-        private void TxtCategory_LostFocus(object sender, RoutedEventArgs e)
-        {
-            TxtCategoryBorder.BorderBrush = string.IsNullOrEmpty(TxtCategory.Text) ? Brushes.Red : Brushes.Transparent;
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
+            }
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/TransferDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/TransferDialog.xaml
@@ -15,7 +15,8 @@
     Closing="ContentDialog_Closing"
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
-        <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:TransferDialog}" />
     </ui:ContentDialog.Resources>
     <StackPanel>
@@ -27,35 +28,40 @@
         </ui:TextBlock>
 
         <ui:TextBlock Margin="0,0,0,4">Transfer from</ui:TextBlock>
-        <Border
-            x:Name="cmbFromBorder"
-            BorderBrush="Transparent"
-            BorderThickness="1">
-            <ComboBox
-                x:Name="cmbFrom"
-                ItemsSource="{Binding Accounts}"
-                LostFocus="cmbFrom_LostFocus"
-                SelectedItem="{Binding TransferFrom}" />
-        </Border>
+        <ComboBox
+            x:Name="cmbFrom"
+            Margin="1,0,2,0"
+            ItemsSource="{Binding Accounts}"
+            SelectedItem="{Binding TransferFrom, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,8"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=cmbFrom, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=cmbFrom, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
         <ui:TextBlock Margin="0,8,0,4">Transfer to</ui:TextBlock>
-        <Border
-            x:Name="cmbToBorder"
-            BorderBrush="Transparent"
-            BorderThickness="1">
-            <ComboBox
-                x:Name="cmbTo"
-                ItemsSource="{Binding Accounts}"
-                LostFocus="cmbTo_LostFocus"
-                SelectedItem="{Binding TransferTo}" />
-        </Border>
+        <ComboBox
+            x:Name="cmbTo"
+            Margin="1,0,2,0"
+            ItemsSource="{Binding Accounts}"
+            SelectedItem="{Binding TransferTo, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,8"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=cmbTo, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=cmbTo, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
 
         <ui:TextBlock Margin="0,8,0,4">Transfer amount</ui:TextBlock>
         <ui:TextBox
             x:Name="txtAmount"
-            Margin="1,0,1,0"
+            Margin="1,0,2,0"
             GotKeyboardFocus="txtAmount_GotFocus"
             KeyDown="txtAmount_KeyDown"
-            Text="{Binding Path=Amount, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding AmountStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtAmount, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtAmount, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/TransferDialog.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Controls;
 using System.Windows.Input;
-using System.Windows.Media;
 using MyMoney.Abstractions;
 using MyMoney.ViewModels.ContentDialogs;
 using Wpf.Ui.Controls;
@@ -23,13 +21,11 @@ namespace MyMoney.Views.ContentDialogs
             txtAmount.SelectAll();
         }
 
-        private void txtAmount_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        private void txtAmount_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == System.Windows.Input.Key.Enter)
+            if (e.Key == Key.Enter)
             {
-                txtAmount.MoveFocus(
-                    new System.Windows.Input.TraversalRequest(System.Windows.Input.FocusNavigationDirection.Next)
-                );
+                txtAmount.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
                 e.Handled = false;
             }
         }
@@ -42,44 +38,15 @@ namespace MyMoney.Views.ContentDialogs
             txtAmount.Focus();
             txtAmount.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
-            // validate the user data, and if it is invalid, prevent the dialog from closing
+            if (DataContext is TransferDialogViewModel vm)
+            {
+                vm.Validate();
 
-            // get validation errors for all the required fields
-            var amountValidationErrors = Validation.GetErrors(txtAmount);
-            var fromHasErrors = cmbFrom.Text == "" || cmbFrom.Text == cmbTo.Text;
-            var toHasErrors = cmbTo.Text == "" || cmbFrom.Text == cmbTo.Text;
-
-            // Clear the red border from custom validated controls
-            cmbFromBorder.BorderBrush = Brushes.Transparent;
-            cmbToBorder.BorderBrush = Brushes.Transparent;
-
-            // validate
-            if (!fromHasErrors && !toHasErrors && amountValidationErrors is not { Count: > 0 })
-                return;
-
-            // Errors, prevent the dialog from cancelling
-            args.Cancel = true;
-
-            if (fromHasErrors)
-                cmbFromBorder.BorderBrush = Brushes.Red;
-            if (toHasErrors)
-                cmbToBorder.BorderBrush = Brushes.Red;
-        }
-
-        private void cmbTo_LostFocus(object sender, RoutedEventArgs e)
-        {
-            if (cmbTo.IsDropDownOpen)
-                return;
-            cmbToBorder.BorderBrush =
-                string.IsNullOrEmpty(cmbTo.Text) || cmbFrom.Text == cmbTo.Text ? Brushes.Red : Brushes.Transparent;
-        }
-
-        private void cmbFrom_LostFocus(object sender, RoutedEventArgs e)
-        {
-            if (cmbFrom.IsDropDownOpen)
-                return;
-            cmbFromBorder.BorderBrush =
-                string.IsNullOrEmpty(cmbFrom.Text) || cmbFrom.Text == cmbTo.Text ? Brushes.Red : Brushes.Transparent;
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
+            }
         }
     }
 }

--- a/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml
+++ b/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml
@@ -19,14 +19,20 @@
     mc:Ignorable="d">
     <ui:ContentDialog.Resources>
         <Style BasedOn="{StaticResource {x:Type ui:ContentDialog}}" TargetType="{x:Type local:UpdateAccountBalanceDialog}" />
-        <converters:CurrencyConverter x:Key="CurrencyConverter" />
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <converters:FirstValidationErrorConverter x:Key="FirstValidationErrorConverter" />
     </ui:ContentDialog.Resources>
     <StackPanel>
         <TextBlock Margin="0,0,0,8">New balance</TextBlock>
         <TextBox
             x:Name="txtBalance"
-            Margin="1,0,1,0"
+            Margin="1,0,2,1"
             GotKeyboardFocus="TextBox_GotKeyboardFocus"
-            Text="{Binding Balance, Converter={StaticResource CurrencyConverter}}" />
+            Text="{Binding BalanceStr, ValidatesOnNotifyDataErrors=True}" />
+        <TextBlock
+            Margin="1,2,2,0"
+            Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+            Text="{Binding ElementName=txtBalance, Path=(Validation.Errors), Converter={StaticResource FirstValidationErrorConverter}}"
+            Visibility="{Binding ElementName=txtBalance, Path=(Validation.HasError), Converter={StaticResource BooleanToVisibilityConverter}}" />
     </StackPanel>
 </ui:ContentDialog>

--- a/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml.cs
+++ b/MyMoney/Views/ContentDialogs/UpdateAccountBalanceDialog.xaml.cs
@@ -34,12 +34,14 @@ namespace MyMoney.Views.ContentDialogs
             txtBalance.Focus();
             txtBalance.MoveFocus(new TraversalRequest(FocusNavigationDirection.Next));
 
-            // validate the user data, and if it is invalid, prevent the dialog from closing
-            var validationErrors = Validation.GetErrors(txtBalance);
-
-            if (validationErrors is { Count: > 0 })
+            if (DataContext is UpdateAccountBalanceDialogViewModel vm)
             {
-                args.Cancel = true;
+                vm.Validate();
+
+                if (vm.HasErrors)
+                {
+                    args.Cancel = true;
+                }
             }
         }
     }

--- a/MyMoney/packages.lock.json
+++ b/MyMoney/packages.lock.json
@@ -63,11 +63,11 @@
       },
       "NCalcSync": {
         "type": "Direct",
-        "requested": "[6.2.0, )",
-        "resolved": "6.2.0",
-        "contentHash": "Pfk3DSX6yAZCT5KS6f6jps2w9wcGzjsglXky6mDNVDsGD9Dl+bapNvsKYRaA1b8CFUseS/Od9yyfxY8V1OwazQ==",
+        "requested": "[6.3.0, )",
+        "resolved": "6.3.0",
+        "contentHash": "r02xI0zZB12Cxelz136/CxyMGNfmXWnxQUXohLaTdXxitVZafEKSaQWuabJwBVrRDCu9Cr09gAKWooplZoS5iw==",
         "dependencies": {
-          "NCalc.Core": "6.2.0"
+          "NCalc.Core": "6.3.0"
         }
       },
       "WPF-UI": {
@@ -369,26 +369,26 @@
       },
       "NCalc.Core": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "9O+2pY8GyqI4snOGKtQA8Vtgyv1pUSgJtauotYJxFRvHK1asUF+vkvXTX12FTUgPCoZ6h1ubZXe+fCXaRBU7+Q==",
+        "resolved": "6.3.0",
+        "contentHash": "DYhNhLVUQk5bNQBVeHoReZqFdR4WU5kptIfjIJHRRNPs7Ph+fOlxVpfwONVG1i0sBlnFQ2mEexCSXcKhfWGI2Q==",
         "dependencies": {
           "ExtendedNumerics.BigDecimal": "3003.0.0.346",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
-          "NCalc.Parser": "6.2.0",
+          "NCalc.Parser": "6.3.0",
           "Parlot": "1.5.7"
         }
       },
       "NCalc.Domain": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "q4O09l7FR6WKH31F727gIehM5x79gNKIW4PY9ll74Dm3LpRwVBh1JiEFcVA9WRNJhy7fnBwkyVnQNuX5S6rwUQ=="
+        "resolved": "6.3.0",
+        "contentHash": "MUuFquLKiW4WwuGK4rSZEZYPxD1j6ZX21dxSpQbHfUnR7oIsV71rkhvMOb1mafQgsZrlSa9c8xBbKrlLxmOPfQ=="
       },
       "NCalc.Parser": {
         "type": "Transitive",
-        "resolved": "6.2.0",
-        "contentHash": "Q/QdZ2xy3KHkfVvmW8ozKRWI84lo9HEje65ohKA6G+KqiwsDLN8Yr5DsNr60PSHTV186GfhPbls3zCtBKDTi3g==",
+        "resolved": "6.3.0",
+        "contentHash": "YMbau/slMZuyAJhcyF/hoa2bG7OLjLcboo13BOWOuK//DzuxM4YQtetQO4hODxkrHSdieELVfRV03Vn9bq7Sog==",
         "dependencies": {
-          "NCalc.Domain": "6.2.0",
+          "NCalc.Domain": "6.3.0",
           "Parlot": "1.5.7"
         }
       },
@@ -467,7 +467,8 @@
         "dependencies": {
           "CommunityToolkit.Mvvm": "[8.4.2, )",
           "CsvHelper": "[33.1.0, )",
-          "LiteDB": "[5.0.21, )"
+          "LiteDB": "[5.0.21, )",
+          "NCalcSync": "[6.3.0, )"
         }
       },
       "CsvHelper": {


### PR DESCRIPTION
## Summary

Adds proper validation across transaction-related dialogs, including transaction, savings category, export, and transfer flows.

## Impact

Users get clearer validation behavior before submitting dialog changes, reducing invalid or incomplete finance records from the UI.

## Validation

- `dotnet test` passed: 110 tests
