### PR TITLE
Add drag and drop to move transactions between accounts

### DIFF
--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
@@ -1,0 +1,221 @@
+using GongSolutions.Wpf.DragDrop;
+using Moq;
+using MyMoney.Abstractions;
+using MyMoney.Core.Database;
+using MyMoney.Core.Exports;
+using MyMoney.Core.Models;
+using MyMoney.Helpers.DropHandlers;
+using MyMoney.Services;
+using System.Windows;
+using Wpf.Ui;
+using Wpf.Ui.Controls;
+
+namespace MyMoney.Tests.ViewModelTests.AccountsViewModel;
+
+[TestClass]
+public class MoveTransactionTests
+{
+    private DatabaseManager _databaseManager = null!;
+    private Mock<IMessageBoxService> _messageBoxService = null!;
+    private MyMoney.ViewModels.Pages.AccountsViewModel _viewModel = null!;
+    private Account _sourceAccount = null!;
+    private Account _destinationAccount = null!;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        _databaseManager = new(new MemoryStream());
+        _messageBoxService = new();
+        _messageBoxService
+            .Setup(service => service.ShowInfoAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(Wpf.Ui.Controls.MessageBoxResult.None);
+
+        _sourceAccount = new Account
+        {
+            Id = 1,
+            AccountName = "Checking",
+            Total = new Currency(150m),
+        };
+        _destinationAccount = new Account
+        {
+            Id = 2,
+            AccountName = "Savings",
+            Total = new Currency(20m),
+        };
+
+        _databaseManager.WriteCollection("Accounts", [_sourceAccount, _destinationAccount]);
+        _viewModel = CreateViewModel();
+        _viewModel.SelectedAccount = _viewModel.Accounts.Single(account => account.Id == 1);
+        _viewModel.SelectedAccountIndex = 0;
+        await _viewModel.LoadTransactions();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _databaseManager.Dispose();
+    }
+
+    [TestMethod]
+    public async Task MoveTransactionAsync_IncomeMovesTransactionAndUpdatesBalances()
+    {
+        var transaction = AddTransaction(new Currency(50m));
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var destination = _viewModel.Accounts.Single(account => account.Id == 2);
+        var selectedAccount = _viewModel.SelectedAccount;
+
+        var result = await _viewModel.MoveTransactionAsync(transaction, destination);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(100m, source.Total.Value);
+        Assert.AreEqual(70m, destination.Total.Value);
+        Assert.AreEqual(2, transaction.AccountId);
+        Assert.IsFalse(_viewModel.SelectedAccountTransactions.Contains(transaction));
+        Assert.AreSame(selectedAccount, _viewModel.SelectedAccount);
+        Assert.IsNull(_viewModel.SelectedTransaction);
+        Assert.AreEqual(-1, _viewModel.SelectedTransactionIndex);
+
+        var persistedTransaction = _databaseManager
+            .GetCollection<Transaction>("Transactions")
+            .Single(item => item.Id == transaction.Id);
+        Assert.AreEqual(2, persistedTransaction.AccountId);
+
+        var persistedAccounts = _databaseManager.GetCollection<Account>("Accounts");
+        Assert.AreEqual(100m, persistedAccounts.Single(account => account.Id == 1).Total.Value);
+        Assert.AreEqual(70m, persistedAccounts.Single(account => account.Id == 2).Total.Value);
+    }
+
+    [TestMethod]
+    public async Task MoveTransactionAsync_ExpenseUsesSignedBalanceMath()
+    {
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var destination = _viewModel.Accounts.Single(account => account.Id == 2);
+        source.Total = new Currency(60m);
+        destination.Total = new Currency(100m);
+        var transaction = AddTransaction(new Currency(-40m));
+
+        var result = await _viewModel.MoveTransactionAsync(transaction, destination);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(100m, source.Total.Value);
+        Assert.AreEqual(60m, destination.Total.Value);
+    }
+
+    [TestMethod]
+    public async Task MoveTransactionAsync_ExpenseExceedingDestinationBalanceIsRejected()
+    {
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var destination = _viewModel.Accounts.Single(account => account.Id == 2);
+        source.Total = new Currency(60m);
+        var transaction = AddTransaction(new Currency(-40m));
+
+        var result = await _viewModel.MoveTransactionAsync(transaction, destination);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(60m, source.Total.Value);
+        Assert.AreEqual(20m, destination.Total.Value);
+        Assert.AreEqual(1, transaction.AccountId);
+        Assert.IsTrue(_viewModel.SelectedAccountTransactions.Contains(transaction));
+        _messageBoxService.Verify(
+            service => service.ShowInfoAsync(
+                "Error",
+                It.Is<string>(message => message.Contains("destination account")),
+                "OK"
+            ),
+            Times.Once
+        );
+
+        var persistedTransaction = _databaseManager
+            .GetCollection<Transaction>("Transactions")
+            .Single(item => item.Id == transaction.Id);
+        Assert.AreEqual(1, persistedTransaction.AccountId);
+    }
+
+    [TestMethod]
+    public async Task MoveTransactionAsync_SameAccountIsRejected()
+    {
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var transaction = AddTransaction(new Currency(50m));
+
+        var result = await _viewModel.MoveTransactionAsync(transaction, source);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(150m, source.Total.Value);
+        Assert.AreEqual(1, transaction.AccountId);
+        Assert.IsTrue(_viewModel.SelectedAccountTransactions.Contains(transaction));
+    }
+
+    [TestMethod]
+    public void DragOver_ValidDestinationAllowsMoveAndHighlightsAccount()
+    {
+        var transaction = new Transaction(DateTime.Today, "Payee", new(), new Currency(50m), "")
+        {
+            AccountId = 1,
+        };
+        var dropInfo = CreateDropInfo(transaction, _viewModel.Accounts.Single(account => account.Id == 2));
+        var handler = new TransactionAccountDropHandler(_viewModel);
+
+        handler.DragOver(dropInfo.Object);
+
+        Assert.AreEqual(DragDropEffects.Move, dropInfo.Object.Effects);
+        Assert.AreEqual(DropTargetAdorners.Highlight, dropInfo.Object.DropTargetAdorner);
+    }
+
+    [TestMethod]
+    public void DragOver_SameAccountInvalidDataOrInvalidTargetRejectsDrop()
+    {
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var transaction = new Transaction(DateTime.Today, "Payee", new(), new Currency(50m), "")
+        {
+            AccountId = source.Id,
+        };
+        var sameAccountDrop = CreateDropInfo(transaction, source);
+        var invalidDrop = CreateDropInfo("not a transaction", _destinationAccount);
+        var invalidTargetDrop = CreateDropInfo(transaction, "not an account");
+        var handler = new TransactionAccountDropHandler(_viewModel);
+
+        handler.DragOver(sameAccountDrop.Object);
+        handler.DragOver(invalidDrop.Object);
+        handler.DragOver(invalidTargetDrop.Object);
+
+        Assert.AreEqual(DragDropEffects.None, sameAccountDrop.Object.Effects);
+        Assert.AreEqual(DragDropEffects.None, invalidDrop.Object.Effects);
+        Assert.AreEqual(DragDropEffects.None, invalidTargetDrop.Object.Effects);
+    }
+
+    private Transaction AddTransaction(Currency amount)
+    {
+        var transaction = new Transaction(DateTime.Today, "Payee", new(), amount, "")
+        {
+            Id = 10,
+            AccountId = 1,
+        };
+        _databaseManager.WriteCollection("Transactions", [transaction]);
+        _viewModel.SelectedAccountTransactions.Add(transaction);
+        _viewModel.SelectedTransaction = transaction;
+        _viewModel.SelectedTransactionIndex = 0;
+        return transaction;
+    }
+
+    private static Mock<IDropInfo> CreateDropInfo(object data, object targetItem)
+    {
+        var dropInfo = new Mock<IDropInfo>();
+        dropInfo.SetupGet(info => info.Data).Returns(data);
+        dropInfo.SetupGet(info => info.TargetItem).Returns(targetItem);
+        dropInfo.SetupProperty(info => info.Effects);
+        dropInfo.SetupProperty(info => info.DropTargetAdorner);
+        return dropInfo;
+    }
+
+    private MyMoney.ViewModels.Pages.AccountsViewModel CreateViewModel()
+    {
+        return new(
+            Mock.Of<IContentDialogService>(),
+            _databaseManager,
+            _messageBoxService.Object,
+            Mock.Of<IContentDialogFactory>(),
+            Mock.Of<IFileDialogService>(),
+            Mock.Of<ITransactionCsvExporter>()
+        );
+    }
+}

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
@@ -132,6 +132,36 @@ public class MoveTransactionTests
     }
 
     [TestMethod]
+    public async Task MoveTransactionAsync_IncomeExceedingSourceBalanceIsRejected()
+    {
+        var source = _viewModel.Accounts.Single(account => account.Id == 1);
+        var destination = _viewModel.Accounts.Single(account => account.Id == 2);
+        source.Total = new Currency(20m);
+        var transaction = AddTransaction(new Currency(50m));
+
+        var result = await _viewModel.MoveTransactionAsync(transaction, destination);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(20m, source.Total.Value);
+        Assert.AreEqual(20m, destination.Total.Value);
+        Assert.AreEqual(1, transaction.AccountId);
+        Assert.IsTrue(_viewModel.SelectedAccountTransactions.Contains(transaction));
+        _messageBoxService.Verify(
+            service => service.ShowInfoAsync(
+                "Insufficient Funds",
+                It.Is<string>(message => message.Contains("source account")),
+                "OK"
+            ),
+            Times.Once
+        );
+
+        var persistedTransaction = _databaseManager
+            .GetCollection<Transaction>("Transactions")
+            .Single(item => item.Id == transaction.Id);
+        Assert.AreEqual(1, persistedTransaction.AccountId);
+    }
+
+    [TestMethod]
     public async Task MoveTransactionAsync_SameAccountIsRejected()
     {
         var source = _viewModel.Accounts.Single(account => account.Id == 1);

--- a/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
+++ b/MyMoney.Tests/ViewModelTests/AccountsViewModel/MoveTransaction.cs
@@ -118,7 +118,7 @@ public class MoveTransactionTests
         Assert.IsTrue(_viewModel.SelectedAccountTransactions.Contains(transaction));
         _messageBoxService.Verify(
             service => service.ShowInfoAsync(
-                "Error",
+                "Insufficient Funds",
                 It.Is<string>(message => message.Contains("destination account")),
                 "OK"
             ),

--- a/MyMoney/Helpers/DropHandlers/TransactionAccountDropHandler.cs
+++ b/MyMoney/Helpers/DropHandlers/TransactionAccountDropHandler.cs
@@ -1,0 +1,54 @@
+using GongSolutions.Wpf.DragDrop;
+using MyMoney.Core.Models;
+using MyMoney.ViewModels.Pages;
+
+namespace MyMoney.Helpers.DropHandlers;
+
+public sealed class TransactionAccountDropHandler(AccountsViewModel viewModel) : IDropTarget
+{
+    private readonly AccountsViewModel _viewModel = viewModel;
+
+    public void DragOver(IDropInfo dropInfo)
+    {
+        if (IsValidDrop(dropInfo, out _, out _))
+        {
+            dropInfo.Effects = DragDropEffects.Move;
+            dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
+        }
+        else
+        {
+            dropInfo.Effects = DragDropEffects.None;
+        }
+    }
+
+    public async void Drop(IDropInfo dropInfo)
+    {
+        if (!IsValidDrop(dropInfo, out var transaction, out var destinationAccount))
+            return;
+
+        await _viewModel.MoveTransactionAsync(transaction, destinationAccount);
+    }
+
+    private static bool IsValidDrop(
+        IDropInfo dropInfo,
+        out Transaction transaction,
+        out Account destinationAccount
+    )
+    {
+        transaction = null!;
+        destinationAccount = null!;
+
+        if (dropInfo.Data is not Transaction draggedTransaction)
+            return false;
+
+        if (dropInfo.TargetItem is not Account targetAccount)
+            return false;
+
+        if (draggedTransaction.AccountId == targetAccount.Id)
+            return false;
+
+        transaction = draggedTransaction;
+        destinationAccount = targetAccount;
+        return true;
+    }
+}

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -377,6 +377,18 @@ namespace MyMoney.ViewModels.Pages
             }
 
             if (
+                transaction.Amount.Value > 0m
+                && !await ValidateTransactionAmount(
+                    transaction.Amount,
+                    sourceAccount,
+                    "source"
+                )
+            )
+            {
+                return false;
+            }
+
+            if (
                 transaction.Amount.Value < 0m
                 && !await ValidateTransactionAmount(
                     new Currency(Math.Abs(transaction.Amount.Value)),

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -211,7 +211,7 @@ namespace MyMoney.ViewModels.Pages
             if (!result.IsValid)
             {
                 await _messageBoxService.ShowInfoAsync(
-                    "Error",
+                    "Insufficient Funds",
                     $"The amount of this transaction is greater than the balance of the {accountDescription} account.",
                     "OK"
                 );

--- a/MyMoney/ViewModels/Pages/AccountsViewModel.cs
+++ b/MyMoney/ViewModels/Pages/AccountsViewModel.cs
@@ -4,6 +4,7 @@ using MyMoney.Core.Exports;
 using MyMoney.Core.Models;
 using MyMoney.Core.Services.Accounts;
 using MyMoney.Core.Services.Budgets;
+using MyMoney.Helpers.DropHandlers;
 using MyMoney.Services;
 using MyMoney.ViewModels.ContentDialogs;
 using MyMoney.Views.ContentDialogs;
@@ -27,6 +28,8 @@ namespace MyMoney.ViewModels.Pages
         /// Transactions for the currently selected account
         /// </summary>
         public ObservableCollection<Transaction> SelectedAccountTransactions { get; set; } = [];
+
+        public TransactionAccountDropHandler TransactionAccountDropHandler { get; }
 
         // Observable properties
         [ObservableProperty]
@@ -104,6 +107,7 @@ namespace MyMoney.ViewModels.Pages
             _accountValidationService = accountValidationService ?? new AccountValidationService();
             _savingsCategoryTransactionSyncService =
                 savingsCategoryTransactionSyncService ?? new SavingsCategoryTransactionSyncService(databaseManager);
+            TransactionAccountDropHandler = new(this);
 
             LoadAccounts();
         }
@@ -197,14 +201,18 @@ namespace MyMoney.ViewModels.Pages
             _databaseManager.WriteCollection("Accounts", [.. Accounts]);
         }
 
-        private async Task<bool> ValidateTransactionAmount(Currency amount, Account account)
+        private async Task<bool> ValidateTransactionAmount(
+            Currency amount,
+            Account account,
+            string accountDescription = "selected"
+        )
         {
             var result = _accountValidationService.ValidateTransactionAmount(amount, account);
             if (!result.IsValid)
             {
                 await _messageBoxService.ShowInfoAsync(
                     "Error",
-                    "The amount of this transaction is greater than the balance of the selected account.",
+                    $"The amount of this transaction is greater than the balance of the {accountDescription} account.",
                     "OK"
                 );
                 return false;
@@ -351,6 +359,47 @@ namespace MyMoney.ViewModels.Pages
             UpdateSavingsCategory(transaction, TransactionOperation.Add);
 
             SaveAccountsToDatabase();
+        }
+
+        public async Task<bool> MoveTransactionAsync(
+            Transaction transaction,
+            Account destinationAccount
+        )
+        {
+            var sourceAccount = Accounts.FirstOrDefault(account => account.Id == transaction.AccountId);
+            if (
+                sourceAccount == null
+                || !Accounts.Contains(destinationAccount)
+                || sourceAccount.Id == destinationAccount.Id
+            )
+            {
+                return false;
+            }
+
+            if (
+                transaction.Amount.Value < 0m
+                && !await ValidateTransactionAmount(
+                    new Currency(Math.Abs(transaction.Amount.Value)),
+                    destinationAccount,
+                    "destination"
+                )
+            )
+            {
+                return false;
+            }
+
+            _accountTransactionService.ApplyTransactionChange(sourceAccount, transaction);
+            _accountTransactionService.ApplyTransactionChange(destinationAccount, null, transaction);
+            transaction.AccountId = destinationAccount.Id;
+
+            _databaseManager.Update("Transactions", transaction);
+            SaveAccountsToDatabase();
+
+            SelectedAccountTransactions.Remove(transaction);
+            SelectedTransaction = null;
+            SelectedTransactionIndex = -1;
+
+            return true;
         }
 
         [RelayCommand]

--- a/MyMoney/Views/Pages/AccountsPage.xaml
+++ b/MyMoney/Views/Pages/AccountsPage.xaml
@@ -7,6 +7,7 @@
     xmlns:converters="clr-namespace:MyMoney.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:dataannotations="clr-namespace:System.ComponentModel.DataAnnotations;assembly=System.ComponentModel.DataAnnotations"
+    xmlns:dd="urn:gong-wpf-dragdrop"
     xmlns:local="clr-namespace:MyMoney.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:MyMoney.Core.Models;assembly=MyMoney.Core"
@@ -106,6 +107,8 @@
                     SelectedIndex="{Binding ViewModel.SelectedAccountIndex}"
                     SelectedItem="{Binding ViewModel.SelectedAccount}"
                     SelectionChanged="AccountsList_SelectionChanged"
+                    dd:DragDrop.DropHandler="{Binding ViewModel.TransactionAccountDropHandler}"
+                    dd:DragDrop.IsDropTarget="True"
                     Tag="{Binding DataContext, RelativeSource={RelativeSource Self}}">
 
                     <ui:ListView.Resources>
@@ -231,6 +234,7 @@
                         ScrollViewer.ScrollChanged="TransactionsList_ScrollChanged"
                         SelectedIndex="{Binding ViewModel.SelectedTransactionIndex}"
                         SelectedItem="{Binding ViewModel.SelectedTransaction}"
+                        dd:DragDrop.IsDragSource="True"
                         Tag="{Binding}"
                         VirtualizingPanel.IsVirtualizing="True"
                         VirtualizingPanel.ScrollUnit="Pixel"


### PR DESCRIPTION
This allows transactions from one account to be dragged to another account and moved there. The transaction is removed from the original account, added to the new one, and then both account balances are updated.

Closes #382